### PR TITLE
Update Blueprint & update onTap API

### DIFF
--- a/BlueprintUILists/Tests/ListPerformanceTesting.swift
+++ b/BlueprintUILists/Tests/ListPerformanceTesting.swift
@@ -85,7 +85,7 @@ fileprivate struct Label : UIViewElement {
     
     var text : String
     
-    static func makeUIView() -> UILabel {
+    func makeUIView() -> UILabel {
         return UILabel()
     }
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Changed
 
+- `onTap` on `HeaderFooter` now takes no parameters, to disambiguate it from `configure`.
+
 ### Misc
 
 # Past Releases

--- a/Demo/Sources/Demos/Demo Screens/AccordionViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/AccordionViewController.swift
@@ -23,7 +23,7 @@ final class AccordionViewController : ListViewController
                 
                 section.header = HeaderFooter(
                     AccordionHeader(text: "Section Header #\(sectionIndex)"),
-                    onTap: { _ in
+                    onTap: {
                         self.expandedSectionIndex = sectionIndex
                         self.reload(animated: true)
                     }

--- a/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
+++ b/ListableUI/Sources/HeaderFooter/HeaderFooter.swift
@@ -17,7 +17,7 @@ public struct HeaderFooter<Content:HeaderFooterContent> : AnyHeaderFooter
     public var sizing : Sizing
     public var layouts : HeaderFooterLayouts
     
-    public typealias OnTap = (Content) -> ()
+    public typealias OnTap = () -> ()
     public var onTap : OnTap?
     
     public var debuggingIdentifier : String? = nil

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.HeaderFooterState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.HeaderFooterState.swift
@@ -146,12 +146,7 @@ extension PresentationState
                 pressed: view.pressedBackground
             )
             
-            view.onTap = self.model.onTap.map { onTap in { [weak self] in
-                    guard let self = self else { return }
-                    
-                    onTap(self.model.content)
-                }
-            }
+            view.onTap = self.model.onTap
             
             self.model.content.apply(to: views, for: reason, with: info)
         }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - BlueprintUI (0.27.0)
-  - BlueprintUICommonControls (0.27.0):
-    - BlueprintUI
+  - BlueprintUI (0.29.0)
+  - BlueprintUICommonControls (0.29.0):
+    - BlueprintUI (= 0.29.0)
   - BlueprintUILists (0.28.0):
     - BlueprintUI
     - ListableUI
@@ -43,8 +43,8 @@ EXTERNAL SOURCES:
     :path: Internal Pods/Snapshot/Snapshot.podspec
 
 SPEC CHECKSUMS:
-  BlueprintUI: 0fe7dfb34d43c8ff1b6b69ca1bce853fa1eda084
-  BlueprintUICommonControls: e228bcd0a6918d52465d300a0dbce0bceaab4674
+  BlueprintUI: 8ec10c92e21f41f4394024275412bcea6bc67d80
+  BlueprintUICommonControls: 7c16f54ae99c2e8a2bd5d229d507b8d536bb7046
   BlueprintUILists: 609f3a41034b29d107d5fe1ef14ed415065d1efc
   EnglishDictionary: f03968b9382ddc5c8dd63535efbf783c6cd45f1c
   ListableUI: 0557ea8b43f75a7e3be6efe90a723f66144b5fe4


### PR DESCRIPTION
- Update Blueprint
- Remove onTap handler from HeaderFooter to avoid ambiguity with the configure block.