### PR TITLE
Remove erroneous weak reference, bump to 0.29.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 # Past Releases
 
+# [0.29.2] - 2021-10-21
+
+### Fixed
+
+- Fixed an erroneous `weak` reference in `SupplementaryContainerView` which lead to contents being deallocated too early – this is not actually needed. `HeaderFooterViewStatePair` holds the reference to the contained `AnyPresentationHeaderFooterState`, there are not direct strong references from `AnyPresentationHeaderFooterState` to `SupplementaryContainerView`.
+
 # [0.29.1] - 2021-10-18
 
 ### Fixed
@@ -504,7 +510,8 @@ listActions.scrolling.scrollToSection(
 Earlier releases were ad-hoc and not tracked. To see all changes, please reference [closed PRs on Github](https://github.com/kyleve/Listable/pulls?q=is%3Apr+is%3Aclosed).
 
 
-[Main]: https://github.com/kyleve/Listable/compare/0.29.1...HEAD
+[Main]: https://github.com/kyleve/Listable/compare/0.29.2...HEAD
+[0.29.2]: https://github.com/kyleve/Listable/compare/0.29.1...0.29.2
 [0.29.1]: https://github.com/kyleve/Listable/compare/0.29.0...0.29.1
 [0.29.0]: https://github.com/kyleve/Listable/compare/0.28.0...0.29.0
 [0.28.0]: https://github.com/kyleve/Listable/compare/0.27.1...0.28.0

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -28,7 +28,7 @@ public final class DemosRootViewController : ListViewController
         
         list.content.overscrollFooter = DemoHeader(title: "Thanks for using Listable!!")
         
-        list("list-view") { section in
+        list("list-view") {  [weak self] section in
             
             section.header = DemoHeader(title: "List Views")
             
@@ -36,7 +36,7 @@ public final class DemosRootViewController : ListViewController
                 DemoItem(text: "Basic Demo"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(CollectionViewBasicDemoViewController())
+                    self?.push(CollectionViewBasicDemoViewController())
                 }
             )
             
@@ -44,14 +44,14 @@ public final class DemosRootViewController : ListViewController
                 DemoItem(text: "Blueprint Integration"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(BlueprintListDemoViewController())
+                    self?.push(BlueprintListDemoViewController())
             })
 
             section += Item(
                 DemoItem(text: "Auto Scrolling (Bottom Pin)"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(AutoScrollingViewController())
+                    self?.push(AutoScrollingViewController())
             })
             
             if #available(iOS 13.0, *) {
@@ -59,7 +59,7 @@ public final class DemosRootViewController : ListViewController
                     DemoItem(text: "List State & State Reader"),
                     selectionStyle: .selectable(),
                     onSelect: { _ in
-                        self.push(ListStateViewController())
+                        self?.push(ListStateViewController())
                     }
                 )
             }
@@ -68,91 +68,91 @@ public final class DemosRootViewController : ListViewController
                 DemoItem(text: "Itemization Editor"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(ItemizationEditorViewController())
+                    self?.push(ItemizationEditorViewController())
             })
             
             section += Item(
                 DemoItem(text: "English Dictionary Search"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(CollectionViewDictionaryDemoViewController())
+                    self?.push(CollectionViewDictionaryDemoViewController())
             })
             
             section += Item(
                 DemoItem(text: "Keyboard Inset (Full Screen List)"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(KeyboardTestingViewController())
+                    self?.push(KeyboardTestingViewController())
             })
             
             section += Item(
                 DemoItem(text: "Keyboard Inset (Appears Later)"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(ListAppearsAfterKeyboardViewController())
+                    self?.push(ListAppearsAfterKeyboardViewController())
             })
             
             section += Item(
                 DemoItem(text: "Reordering"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(ReorderingViewController())
+                    self?.push(ReorderingViewController())
             })
             
             section += Item(
                 DemoItem(text: "Payment Types (Reordering)"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(PaymentTypesViewController())
+                    self?.push(PaymentTypesViewController())
             })
             
             section += Item(
                 DemoItem(text: "Multi-Select"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(MultiSelectViewController())
+                    self?.push(MultiSelectViewController())
             })
             
             section += Item(
                 DemoItem(text: "Invoices Payment Schedule"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(InvoicesPaymentScheduleDemoViewController())
+                    self?.push(InvoicesPaymentScheduleDemoViewController())
             })
 
             section += Item(
                 DemoItem(text: "Refresh Control"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(RefreshControlOffsetAdjustmentViewController())
+                    self?.push(RefreshControlOffsetAdjustmentViewController())
             })
             
             section += Item(
                 DemoItem(text: "Swipe Actions"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(SwipeActionsViewController())
+                    self?.push(SwipeActionsViewController())
             })
             
             section += Item(
                 DemoItem(text: "Localized Collation"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(LocalizedCollationViewController())
+                    self?.push(LocalizedCollationViewController())
             })
             
             section += Item(
                 DemoItem(text: "Item Insert & Remove Animations"),
                 selectionStyle: .selectable(),
                 onSelect: { _ in
-                    self.push(ItemInsertAndRemoveAnimationsViewController())
+                    self?.push(ItemInsertAndRemoveAnimationsViewController())
             })
 
             section += Item(
                 DemoItem(text: "Manual Selection Management"),
                 selectionStyle: .selectable(),
                 onSelect: { _ in
-                    self.push(ManualSelectionManagementViewController())
+                    self?.push(ManualSelectionManagementViewController())
                 }
             )
             
@@ -160,18 +160,18 @@ public final class DemosRootViewController : ListViewController
                 DemoItem(text: "Accordion View"),
                 selectionStyle: .tappable,
                 onSelect: { _ in
-                    self.push(AccordionViewController())
+                    self?.push(AccordionViewController())
             })
             
             section += Item(
                 DemoItem(text: "Using Autolayout"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(AutoLayoutDemoViewController())
+                    self?.push(AutoLayoutDemoViewController())
             })
         }
         
-        list("coordinator") { section in
+        list("coordinator") { [weak self] section in
             
             section.header = DemoHeader(title: "Item Coordinator")
             
@@ -179,19 +179,19 @@ public final class DemosRootViewController : ListViewController
                 DemoItem(text: "Expand / Collapse Items"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(CoordinatorViewController())
+                    self?.push(CoordinatorViewController())
             })
             
             section += Item(
                 DemoItem(text: "Animating On Tap"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(OnTapItemAnimationViewController())
+                    self?.push(OnTapItemAnimationViewController())
             })
             
         }
         
-        list("layouts") { section in
+        list("layouts") { [weak self] section in
             
             section.header = DemoHeader(title: "Other Layouts")
             
@@ -199,46 +199,46 @@ public final class DemosRootViewController : ListViewController
                 DemoItem(text: "Grid Layout"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(CustomLayoutsViewController())
+                    self?.push(CustomLayoutsViewController())
             })
             
             section += Item(
                 DemoItem(text: "Paged Layout"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(PagedViewController())
+                    self?.push(PagedViewController())
             })
             
             section += Item(
                 DemoItem(text: "Horizontal Layout"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(HorizontalLayoutViewController())
+                    self?.push(HorizontalLayoutViewController())
             })
             
             section += Item(
                 DemoItem(text: "Width Customization"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(WidthCustomizationViewController())
+                    self?.push(WidthCustomizationViewController())
             })
 
             section += Item(
                 DemoItem(text: "Spacing Customization"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(SpacingCustomizationViewController())
+                    self?.push(SpacingCustomizationViewController())
             })
 
             section += Item(
                 DemoItem(text: "Retail Grid Layout"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(RetailGridViewController())
+                    self?.push(RetailGridViewController())
             })
         }
         
-        list("selection-state") { section in
+        list("selection-state") { [weak self] section in
             
             section.header = DemoHeader(title: "List View Selection")
 
@@ -256,7 +256,7 @@ public final class DemosRootViewController : ListViewController
             )
         }
         
-        list("collection-view") { section in
+        list("collection-view") { [weak self] section in
             
             section.header = DemoHeader(title: "UICollectionViews")
 
@@ -264,11 +264,11 @@ public final class DemosRootViewController : ListViewController
                 DemoItem(text: "Flow Layout"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(FlowLayoutViewController())
+                    self?.push(FlowLayoutViewController())
             })
         }
         
-        list("scroll-view") { section in
+        list("scroll-view") { [weak self] section in
             
             section.header = DemoHeader(title: "UIScrollViews")
             
@@ -276,7 +276,7 @@ public final class DemosRootViewController : ListViewController
                 DemoItem(text: "Edges Playground"),
                 selectionStyle: .selectable(),
                 onSelect : { _ in
-                    self.push(ScrollViewEdgesPlaygroundViewController())
+                    self?.push(ScrollViewEdgesPlaygroundViewController())
             })
         }
     }

--- a/ListableUI/Sources/Internal/SupplementaryContainerView.swift
+++ b/ListableUI/Sources/Internal/SupplementaryContainerView.swift
@@ -75,7 +75,7 @@ final class SupplementaryContainerView : UICollectionReusableView
     // MARK: Content
     //
     
-    weak var headerFooter : AnyPresentationHeaderFooterState? {
+    var headerFooter : AnyPresentationHeaderFooterState? {
         didSet {
             guard oldValue !== self.headerFooter else {
                 return

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,15 +2,15 @@ PODS:
   - BlueprintUI (0.29.0)
   - BlueprintUICommonControls (0.29.0):
     - BlueprintUI (= 0.29.0)
-  - BlueprintUILists (0.29.1):
+  - BlueprintUILists (0.29.2):
     - BlueprintUI
     - ListableUI
-  - BlueprintUILists/Tests (0.29.1):
+  - BlueprintUILists/Tests (0.29.2):
     - BlueprintUI
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
-  - ListableUI (0.29.1)
-  - ListableUI/Tests (0.29.1):
+  - ListableUI (0.29.2)
+  - ListableUI/Tests (0.29.2):
     - EnglishDictionary
     - Snapshot
   - Snapshot (1.0.0.LOCAL)
@@ -45,9 +45,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BlueprintUI: 8ec10c92e21f41f4394024275412bcea6bc67d80
   BlueprintUICommonControls: 7c16f54ae99c2e8a2bd5d229d507b8d536bb7046
-  BlueprintUILists: bdf483fb74e8560659948da85c61b8c857fb87db
+  BlueprintUILists: 2b67fa4613a73fa10e266c64a507b0e6a70a1704
   EnglishDictionary: f03968b9382ddc5c8dd63535efbf783c6cd45f1c
-  ListableUI: bdd110595fe0b6cdcfaecf02b4a0d968e679696a
+  ListableUI: bb2b90ebb2e410bd4d04cc4ebfc5f84f07677fc4
   Snapshot: cda3414db426919d09f775434b36289c8e864183
 
 PODFILE CHECKSUM: 505f47e09640e9b7eadef9a138cfeed056359f76

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-LISTABLE_VERSION ||= '0.29.1'
+LISTABLE_VERSION ||= '0.29.2'


### PR DESCRIPTION
- After pairing with @lokae0 for a bit today, we confirmed what @eugenegrebnev found, which is the `weak` reference in `SupplementaryContainerView` is wrong – this is my bad. I thought that `AnyPresentationHeaderFooterState` had a strong reference to its current `SupplementaryContainerView`, but it does not. The `HeaderFooterStatePair` holds strong references to both of them, but there's no cycle.

This fixes the regression introduced in https://github.com/kyleve/Listable/pull/322.

This also fixes the root view controller in then demo not using weak references for `self`.