### PR TITLE
Fix Update Queueing

### DIFF
--- a/BlueprintUILists/Sources/Internal/Assertions.swift
+++ b/BlueprintUILists/Sources/Internal/Assertions.swift
@@ -50,7 +50,7 @@ func listableInternalPrecondition(
 
 
 /// By default, `precondition` error messages are not included in release builds. We would like that!
-/// https://bugs.swift.org/browse/SR-905
+/// https://github.com/apple/swift/issues/43517
 @inline(__always)
 func precondition(
     _ condition: @autoclosure () -> Bool,
@@ -64,7 +64,7 @@ func precondition(
 }
 
 /// By default, `preconditionFailure` error messages are not included in release builds. We would like that!
-/// https://bugs.swift.org/browse/SR-905
+/// https://github.com/apple/swift/issues/43517
 @inline(__always)
 public func preconditionFailure(
     _ message: @autoclosure () -> String = String(),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fixed an issue where submitting many frequent updates in a large list would cause crashes due to state getting out of sync, hopefully.
+
 ### Added
 
 - You may now control the stickiness of headers within individual sections, eg by setting `section.layouts.table.isHeaderSticky = true/false/nil`, or by implementing `isStickySectionHeader` on your `HeaderFooterContent`. Providing nil for either value falls back to the list-level stickiness setting.

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0A5DC1A924F6FD4200DC7C14 /* ListAppearsAfterKeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5DC1A824F6FD4200DC7C14 /* ListAppearsAfterKeyboardViewController.swift */; };
 		0A5F5CCF257EC2D7003CCE2C /* LocalizedCollationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5F5CCE257EC2D7003CCE2C /* LocalizedCollationViewController.swift */; };
 		0A66420B254A317A007F6B2F /* AutoLayoutDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A66420A254A317A007F6B2F /* AutoLayoutDemoViewController.swift */; };
+		0A7759D728FD923B00FD7C2A /* UpdateFuzzingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7759D628FD923B00FD7C2A /* UpdateFuzzingViewController.swift */; };
 		0A793B5824E4B53500850139 /* ManualSelectionManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A793B5724E4B53500850139 /* ManualSelectionManagementViewController.swift */; };
 		0A87BA652463567B0047C3B5 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 0A87BA642463567B0047C3B5 /* CHANGELOG.md */; };
 		0AA4D9BA248064A300CF95A5 /* SystemFlowLayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA4D9A9248064A200CF95A5 /* SystemFlowLayoutViewController.swift */; };
@@ -31,7 +32,7 @@
 		0AA4D9C4248064A300CF95A5 /* ItemizationEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA4D9B3248064A300CF95A5 /* ItemizationEditorViewController.swift */; };
 		0AA4D9C5248064A300CF95A5 /* AutoScrollingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA4D9B4248064A300CF95A5 /* AutoScrollingViewController.swift */; };
 		0AA4D9C6248064A300CF95A5 /* SwipeActionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA4D9B5248064A300CF95A5 /* SwipeActionsViewController.swift */; };
-		0AA4D9C7248064A300CF95A5 /* CollectionViewDictionaryDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA4D9B6248064A300CF95A5 /* CollectionViewDictionaryDemoViewController.swift */; };
+		0AA4D9C7248064A300CF95A5 /* SearchableDictionaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA4D9B6248064A300CF95A5 /* SearchableDictionaryViewController.swift */; };
 		0AA4D9C8248064A300CF95A5 /* ReorderingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA4D9B7248064A300CF95A5 /* ReorderingViewController.swift */; };
 		0AA4D9C9248064A300CF95A5 /* CollectionViewBasicDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA4D9B8248064A300CF95A5 /* CollectionViewBasicDemoViewController.swift */; };
 		0AC2A1962489F93E00779459 /* PagedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC2A1952489F93E00779459 /* PagedViewController.swift */; };
@@ -65,6 +66,7 @@
 		0A5DC1A824F6FD4200DC7C14 /* ListAppearsAfterKeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAppearsAfterKeyboardViewController.swift; sourceTree = "<group>"; };
 		0A5F5CCE257EC2D7003CCE2C /* LocalizedCollationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedCollationViewController.swift; sourceTree = "<group>"; };
 		0A66420A254A317A007F6B2F /* AutoLayoutDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLayoutDemoViewController.swift; sourceTree = "<group>"; };
+		0A7759D628FD923B00FD7C2A /* UpdateFuzzingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateFuzzingViewController.swift; sourceTree = "<group>"; };
 		0A793B5724E4B53500850139 /* ManualSelectionManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSelectionManagementViewController.swift; sourceTree = "<group>"; };
 		0A87BA642463567B0047C3B5 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
 		0AA4D9A9248064A200CF95A5 /* SystemFlowLayoutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemFlowLayoutViewController.swift; sourceTree = "<group>"; };
@@ -80,7 +82,7 @@
 		0AA4D9B3248064A300CF95A5 /* ItemizationEditorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemizationEditorViewController.swift; sourceTree = "<group>"; };
 		0AA4D9B4248064A300CF95A5 /* AutoScrollingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoScrollingViewController.swift; sourceTree = "<group>"; };
 		0AA4D9B5248064A300CF95A5 /* SwipeActionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeActionsViewController.swift; sourceTree = "<group>"; };
-		0AA4D9B6248064A300CF95A5 /* CollectionViewDictionaryDemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewDictionaryDemoViewController.swift; sourceTree = "<group>"; };
+		0AA4D9B6248064A300CF95A5 /* SearchableDictionaryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchableDictionaryViewController.swift; sourceTree = "<group>"; };
 		0AA4D9B7248064A300CF95A5 /* ReorderingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReorderingViewController.swift; sourceTree = "<group>"; };
 		0AA4D9B8248064A300CF95A5 /* CollectionViewBasicDemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewBasicDemoViewController.swift; sourceTree = "<group>"; };
 		0AC2A1952489F93E00779459 /* PagedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedViewController.swift; sourceTree = "<group>"; };
@@ -150,7 +152,7 @@
 				8ECEBF6128B7E4C200ECEC56 /* CenterSnappingTableViewController.swift */,
 				0AA4D9B2248064A300CF95A5 /* CollectionViewAppearance.swift */,
 				0AA4D9B8248064A300CF95A5 /* CollectionViewBasicDemoViewController.swift */,
-				0AA4D9B6248064A300CF95A5 /* CollectionViewDictionaryDemoViewController.swift */,
+				0AA4D9B6248064A300CF95A5 /* SearchableDictionaryViewController.swift */,
 				0A57BA2C274FFCE000A118BD /* FlowLayoutViewController.swift */,
 				0AA4D9B0248064A300CF95A5 /* CoordinatorViewController.swift */,
 				0AD827DB2752C8A700D42B4A /* CarouselLayoutViewController.swift */,
@@ -163,6 +165,7 @@
 				0A5DC1A824F6FD4200DC7C14 /* ListAppearsAfterKeyboardViewController.swift */,
 				0A07119224BA798400CDF65D /* ListStateViewController.swift */,
 				0A5F5CCE257EC2D7003CCE2C /* LocalizedCollationViewController.swift */,
+				0A7759D628FD923B00FD7C2A /* UpdateFuzzingViewController.swift */,
 				0AD6767925423BE500A49315 /* MultiSelectViewController.swift */,
 				0AC2A1952489F93E00779459 /* PagedViewController.swift */,
 				0AA4D9B7248064A300CF95A5 /* ReorderingViewController.swift */,
@@ -481,7 +484,8 @@
 				0AA4D9BD248064A300CF95A5 /* BlueprintListDemoViewController.swift in Sources */,
 				0AA4D9BB248064A300CF95A5 /* ScrollViewEdgesPlaygroundViewController.swift in Sources */,
 				0ACF96D624A0094D0090EAC4 /* ItemInsertAndRemoveAnimationsViewController.swift in Sources */,
-				0AA4D9C7248064A300CF95A5 /* CollectionViewDictionaryDemoViewController.swift in Sources */,
+				0A7759D728FD923B00FD7C2A /* UpdateFuzzingViewController.swift in Sources */,
+				0AA4D9C7248064A300CF95A5 /* SearchableDictionaryViewController.swift in Sources */,
 				0ADC3B3524907C80008DF2C0 /* XcodePreviewDemo.swift in Sources */,
 				0AD827DC2752C8A700D42B4A /* CarouselLayoutViewController.swift in Sources */,
 				0AD6767A25423BE500A49315 /* MultiSelectViewController.swift in Sources */,

--- a/Demo/Sources/Demos/Demo Screens/SearchableDictionaryViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/SearchableDictionaryViewController.swift
@@ -1,5 +1,5 @@
 //
-//  CollectionViewDictionaryDemoViewController.swift
+//  SearchableDictionaryViewController.swift
 //  CheckoutApplet
 //
 //  Created by Kyle Van Essen on 6/25/19.
@@ -13,7 +13,7 @@ import BlueprintUICommonControls
 import EnglishDictionary
 
 
-final public class CollectionViewDictionaryDemoViewController : UIViewController
+final public class SearchableDictionaryViewController : UIViewController
 {
     let listView = ListView()
     

--- a/Demo/Sources/Demos/Demo Screens/UpdateFuzzingViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/UpdateFuzzingViewController.swift
@@ -1,0 +1,172 @@
+//
+//  UpdateFuzzingViewController.swift
+//  Demo
+//
+//  Created by Kyle Van Essen on 10/17/22.
+//  Copyright © 2022 Kyle Van Essen. All rights reserved.
+//
+
+import UIKit
+import ListableUI
+import BlueprintUILists
+import BlueprintUI
+import BlueprintUICommonControls
+import EnglishDictionary
+
+
+final class UpdateFuzzingViewController : ListViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(title: "Start", style: .plain, target: self, action: #selector(startFuzzing)),
+            UIBarButtonItem(title: "Stop", style: .plain, target: self, action: #selector(stopFuzzing)),
+        ]
+    }
+    
+    private lazy var dictionary = EnglishDictionary.dictionary
+    
+    var isFilterOn : Bool = false
+    
+    override func configure(list: inout ListProperties) {
+        
+        list.layout = .table {
+            
+            $0.bounds = .init(
+                padding: UIEdgeInsets(top: 0.0, left: 20.0, bottom: 20.0, right: 20.0),
+                width: .atMost(600.0)
+            )
+            
+            $0.layout.set {
+                $0.sectionHeaderBottomSpacing = 10.0
+                $0.itemSpacing = 7.0
+                $0.interSectionSpacingWithNoFooter = 10.0
+            }
+        }
+        
+        list += self.dictionary.wordsByLetter.skipHalfMap(skip: isFilterOn) { letter in
+            Section(letter.letter) {
+                letter.words.skipHalfMap(skip: isFilterOn) { word in
+                    Item(
+                        WordRow(title: word.word, detail: word.description),
+                        sizing: .thatFits(.init(.atMost(250.0)))
+                    )
+                }
+            } header: {
+                SectionHeader(title: letter.letter)
+            }
+        }
+    }
+    
+    private var timer : Timer? = nil
+    
+    @objc private func stopFuzzing() {
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    @objc private func startFuzzing() {
+        guard timer == nil else { return }
+        
+        timer = Timer(timeInterval: 0.05, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            
+            self.isFilterOn.toggle()
+            
+            print("Reloading content...")
+            
+            self.reload(animated: true)
+        }
+        
+        RunLoop.current.add(timer!, forMode: .tracking)
+    }
+}
+
+
+fileprivate extension Array {
+    
+    func skipHalfMap<Mapped>(skip : Bool, using block : (Element) -> Mapped) -> [Mapped] {
+        
+        indexedCompactMap { index, element in
+            if index % 2 == 0 && skip {
+                return nil
+            } else {
+                return block(element)
+            }
+        }
+        
+    }
+    
+    func indexedCompactMap<Mapped>(_ map: (Int, Element) -> Mapped?) -> [Mapped] {
+
+        var mapped = [Mapped]()
+
+        for index in indices {
+            if let value = map(index, self[index]) {
+                mapped.append(value)
+            }
+        }
+
+        return mapped
+    }
+}
+
+
+fileprivate struct SectionHeader : BlueprintHeaderFooterContent, Equatable
+{
+    var title : String
+    
+    // MARK: BlueprintItemElement
+    
+    var elementRepresentation: Element {
+        return Box(
+            backgroundColor: UIColor(white: 0.85, alpha: 1.0),
+            cornerStyle: .rounded(radius: 10.0),
+            wrapping: Inset(
+                top: 10.0,
+                bottom: 10.0,
+                left: 20.0,
+                right: 20.0,
+                wrapping: Label(text: self.title) {
+                    $0.font = .systemFont(ofSize: 32.0, weight: .bold)
+            })
+        )
+    }
+    
+    var identifier: String {
+        self.title
+    }
+}
+
+fileprivate struct WordRow : BlueprintItemContent, Equatable
+{
+    var title : String
+    var detail : String
+    
+    // MARK: BlueprintItemElement
+    
+    func element(with info: ApplyItemContentInfo) -> Element
+    {
+        return Box(
+            backgroundColor: .init(white: 0.96, alpha: 1.0),
+            cornerStyle: .rounded(radius: 10.0),
+            wrapping: Inset(top: 10.0, bottom: 10.0, left: 20.0, right: 20.0, wrapping: Column { column in
+                column.add(child: Label(text: self.title) {
+                    $0.font = .systemFont(ofSize: 18.0, weight: .semibold)
+                })
+                
+                column.add(child: Spacer(size: .init(width: 0.0, height: 10.0)))
+                
+                column.add(child: Label(text: self.detail) {
+                    $0.font = .italicSystemFont(ofSize: 14.0)
+                    $0.color = .darkGray
+                })
+            })
+        )
+    }
+    
+    var identifierValue: String {
+        self.title
+    }
+}

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -87,7 +87,7 @@ public final class DemosRootViewController : ListViewController
                     DemoItem(text: "English Dictionary Search"),
                     selectionStyle: .selectable(),
                     onSelect : { _ in
-                        self?.push(CollectionViewDictionaryDemoViewController())
+                        self?.push(SearchableDictionaryViewController())
                     }
                 )
                 
@@ -294,6 +294,19 @@ public final class DemosRootViewController : ListViewController
                 )
             } header: {
                 DemoHeader(title: "Other Layouts")
+            }
+            
+            Section("fuzzing") { [weak self] in
+
+                Item(
+                    DemoItem(text: "Fuzz Testing"),
+                    selectionStyle: .selectable(),
+                    onSelect : { _ in
+                        self?.push(UpdateFuzzingViewController())
+                    }
+                )
+            } header: {
+                DemoHeader(title: "Fuzz Testing")
             }
             
             Section("selection-state") {

--- a/ListableUI/Sources/Internal/Assertions.swift
+++ b/ListableUI/Sources/Internal/Assertions.swift
@@ -50,7 +50,7 @@ func listableInternalPrecondition(
 
 
 /// By default, `precondition` error messages are not included in release builds. We would like that!
-/// https://bugs.swift.org/browse/SR-905
+/// https://github.com/apple/swift/issues/43517
 @inline(__always)
 func precondition(
     _ condition: @autoclosure () -> Bool,
@@ -64,7 +64,7 @@ func precondition(
 }
 
 /// By default, `preconditionFailure` error messages are not included in release builds. We would like that!
-/// https://bugs.swift.org/browse/SR-905
+/// https://github.com/apple/swift/issues/43517
 @inline(__always)
 public func preconditionFailure(
     _ message: @autoclosure () -> String = String(),

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.swift
@@ -362,8 +362,8 @@ final class PresentationState
             environment: environment
         )
         
-        self.sections = diff.changes.transform(
-            old: self.sections,
+        self.sections = diff.transform(
+            input: self.sections,
             removed: { _, section in
                 section.wasRemoved(updateCallbacks: updateCallbacks)
             },
@@ -396,7 +396,9 @@ final class PresentationState
                     dependencies: dependencies,
                     updateCallbacks: updateCallbacks
                 )
-            }
+            },
+            mappedItemCount: \.items.count,
+            sectionItemCount: \.items.count
         )
     }
     

--- a/ListableUI/Sources/ListView/ListChangesQueue.swift
+++ b/ListableUI/Sources/ListView/ListChangesQueue.swift
@@ -8,13 +8,99 @@
 import Foundation
 
 
-/// Used to queue updates into a list view.
-/// Note: This type is only safe to use from the main thread.
+/// A queue used to synchronized and serialize changes made to the backing collection view,
+/// to work around either bugs or confusing behavior.
+///
+/// ## Handling Re-ordering (`isQueuingForReorderEvent`)
+/// Collection View has an issue wherein if you perform a re-order event, and then within
+/// the same runloop, deliver an update to the collection view as a result of that re-order event
+/// that removes a row or section, the collection view will crash because it's internal index path
+/// cache / data model has  not yet been updated. Thus, in `collectionView(_:,moveItemAt:,to:)`,
+/// we set this value to `true`, and then after one runloop, we set it back to `false`, after
+/// the collection view's updates have "settled". Please see `sendEndQueuingEditsAfterDelay` for more.
+///
+/// ## Handling async batch updates (`add(async:)`)
+/// Because we peform updates to _our_ backing data model (`PresentationState`) alongside
+/// our collection view in order to make sure they remain in sync, we need to handle cases where
+/// `UICollectionView.performBatchUpdates(_:completion:)` does not synchronously
+/// invoke its `update` block, which means state can get out of sync.
+/// See `updatePresentationStateWith(firstVisibleIndexPath:for:completion:)` for more.
+///
+/// ## Misc
+/// Why not use `NSOperationQueue` here?
+/// Namely, because we want operations to be synchronous when possible.
+///
+/// Eg, if if you perform the following changes:
+///
+/// ```
+/// list.something()
+///
+/// // A synchronous operation.
+/// queue.add {
+///     doSomethingElse()
+/// }
+///
+/// // An operation which may be synchronous or asynchronous,
+/// // depending on when the completion callback fires.
+/// queue.add { completion in
+///     doAnotherThing(onCompletion: completion.finished)
+/// }
+/// ```
+/// Where the first block can be run immediately (eg the queue is not paused),
+/// it will be performed once the queue callback returns, and without jumping threads at all.
+///
+/// The second block might invoke its `onCompletion` immediately,
+/// or it might take a runloop or two to do so. This implementation ensures
+/// that if the completion block is invoked immediately (eg inline), the operation will also be synchronous.
+/// The main use case for this case is `UICollectionView` callbacks which are sometimes
+/// executed after a few runloop cycles – we don't want _every_ event going through
+/// the queue to delay its completion by a runloop cycle unless we have to.
+///
+/// Only one operation will execute at once. This is a FIFO queue.
+///
 final class ListChangesQueue {
         
     /// Adds a synchronous block to the queue, marked as done once the block exits.
-    func add(_ block : @escaping () -> ()) {
-        self.waiting.append(.init(block))
+    func add(sync block : @escaping () -> ()) {
+        preconditionMainThread()
+        
+        let operation = Operation(
+            kind: .synchronous(
+                .new(.init(body: block))
+            )
+        )
+        
+        self.waiting.append(operation)
+        
+        self.runIfNeeded()
+    }
+    
+    /// Adds an asynchronous block to the queue, marked as done once `Completion.finished()` is called.
+    /// If `finished()` is called inline, the operation will be executed synchronously.
+    func add(async block : @escaping (Completion) -> ()) {
+        preconditionMainThread()
+        
+        let operation = Operation(
+            kind: .asynchronous(
+                .new(
+                    .init(
+                        completion: Completion(),
+                        body: { operation, completion in
+                            
+                            completion.onFinish = { [weak self, weak operation] in
+                                operation?.kind = .asynchronous(.completed)
+                                self?.runIfNeeded()
+                            }
+                            
+                            block(completion)
+                        }
+                    )
+                )
+            )
+        )
+        
+        self.waiting.append(operation)
+        
         self.runIfNeeded()
     }
     
@@ -32,68 +118,173 @@ final class ListChangesQueue {
         self.isQueuingForReorderEvent
     }
     
-    /// Operations waiting to execute.
+    /// Operations waiting to execute, or in the case of asynchronous operations,
+    /// they may already be operating.
     private(set) var waiting : [Operation] = []
+    
+    private var isRunning : Bool = false
     
     /// Invoked to continue processing queue events.
     private func runIfNeeded() {
-        precondition(Thread.isMainThread)
+        preconditionMainThread()
+
+        guard isRunning == false else { return }
         
-        /// Nothing to do if we're currently paused!
-        guard self.isPaused == false else {
-            return
-        }
+        defer { isRunning = false }
         
-        while let next = self.waiting.popFirst() {
-            autoreleasepool {
-                guard case .new(let new) = next.state else {
-                    fatalError("State of enqueued operation was wrong")
+        isRunning = true
+        
+        while let current = self.waiting.first {
+            
+            guard self.isPaused == false else { return }
+            
+            var shouldBreak : Bool = false
+            
+            current.ifSynchronous { sync in
+                switch sync {
+                case .new(let content):
+                    content.body()
+                    sync = .completed
+                    
+                    self.waiting.removeFirst()
+                    
+                case .completed:
+                    fatalError("Should not be able to enumerate a completed synchronous operation.")
                 }
                 
-                /// Ok, we have a runnable operation; let's run it.
+                shouldBreak = false
                 
-                next.state = .done
-                
-                new.body()
+            } ifAsynchronous: { async in
+                switch async {
+                case .new(let content):
+                    async = .running(content)
+                    content.body(current, content.completion)
+                    
+                    /// Even though this is an async operation;
+                    /// its possible (and allowed) to call the completion
+                    /// block synchronously – let's ensure we handle that!
+                    
+                    if current.kind.isCompleted {
+                        shouldBreak = false
+                        self.waiting.removeFirst()
+                    } else {
+                        shouldBreak = true
+                    }
+                case .running:
+                    shouldBreak = true
+                case .completed:
+                    self.waiting.removeFirst()
+                }
+            }
+            
+            if shouldBreak {
+                break
             }
         }
+    }
+    
+    private func preconditionMainThread() {
+        precondition(
+            Thread.isMainThread,
+            "ListChangesQueue must run on main thread. Instead, it was \(Thread.current)."
+        )
     }
 }
 
 
 extension ListChangesQueue {
-    
+        
     final class Operation {
         
-        fileprivate(set) var state : State
+        fileprivate(set) var kind : Kind
         
-        init(_ body : @escaping () -> ()) {
-            self.state = .new(.init(body: body))
+        init(kind : Kind) {
+            self.kind = kind
         }
         
-        enum State {
-            case new(New)
-            case done
+        /// Helper method for accessing (and mutating) the state
+        /// of each separate type of operation.
+        func ifSynchronous(
+            _ synchronous : (inout Kind.Synchronous) -> (),
+            ifAsynchronous asynchronous : (inout Kind.Asynchronous) -> ()
+        ) {
+            switch self.kind {
+            case .synchronous(var content):
+                synchronous(&content)
+                self.kind = .synchronous(content)
+                
+            case .asynchronous(var content):
+                asynchronous(&content)
+                self.kind = .asynchronous(content)
+            }
+        }
+        
+        /// The kind of operation, sync or async. Note that
+        /// the synchronous operation has to track less state,
+        /// and thus has fewer cases and stored properties.
+        enum Kind {
+            case synchronous(Synchronous)
+            case asynchronous(Asynchronous)
             
-            struct New {
-                let body : () -> ()
+            var isCompleted : Bool {
+                switch self {
+                case .synchronous(let sync): return sync.isCompleted
+                case .asynchronous(let async): return async.isCompleted
+                }
+            }
+            
+            enum Synchronous {
+                case new(Content)
+                case completed
+                
+                var isCompleted : Bool {
+                    switch self {
+                    case .new: return false
+                    case .completed: return true
+                    }
+                }
+                
+                struct Content {
+                    let body : () -> ()
+                }
+            }
+            
+            enum Asynchronous {
+                case new(Content)
+                case running(Content)
+                case completed
+                
+                var isCompleted : Bool {
+                    switch self {
+                    case .new, .running: return false
+                    case .completed: return true
+                    }
+                }
+                
+                struct Content {
+                    let completion : Completion
+                    let body : (Operation, Completion) -> ()
+                }
             }
         }
     }
-}
-
-
-fileprivate extension Array {
     
-    mutating func popFirst() -> Element? {
-        guard self.isEmpty == false else {
-            return nil
+    final class Completion {
+
+        fileprivate var onFinish : () -> () = {
+            fatalError("onFinish must be set before the completion operation is used.")
         }
         
-        let first = self[0]
+        private var isFinished : Bool = false
         
-        self.remove(at: 0)
-        
-        return first
+        /// Invoked by callers when their async work completed.
+        /// If this method is called more than once, a fatal error occurs.
+        func finished() {
+            precondition(isFinished == false, "Cannot finish an operation more than once.")
+            
+            isFinished = true
+            
+            onFinish()
+        }
     }
 }

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1021,7 +1021,7 @@ public final class ListView : UIView, KeyboardObserverDelegate
         self.updateQueue.add { [weak self] completion in
             
             guard let self = self else {
-                completion.finished()
+                completion.finish()
                 return
             }
             
@@ -1077,9 +1077,7 @@ public final class ListView : UIView, KeyboardObserverDelegate
                 with: diff,
                 animated: reason.animated,
                 updateBackingData: updateBackingData,
-                collectionViewUpdateCompletion: {
-                    completion.finished()
-                },
+                collectionViewUpdateCompletion: completion.finish,
                 animationCompletion: callerCompletion
             )
 

--- a/ListableUI/Tests/Internal/Diff/ArrayDiffTests.swift
+++ b/ListableUI/Tests/Internal/Diff/ArrayDiffTests.swift
@@ -359,7 +359,7 @@ class ArrayDiffTests: XCTestCase
     
     func test_transform_with_random_mutations()
     {
-        let iterations : Int = 500
+        let iterations : Int = 2000
         
         var rng = StableRNG()
         

--- a/ListableUI/Tests/ListView/ListChangesQueueTests.swift
+++ b/ListableUI/Tests/ListView/ListChangesQueueTests.swift
@@ -29,10 +29,10 @@ class ListChangesQueueTests : XCTestCase {
         queue.add { completion in
             calls += [2]
             
-            completion.finished()
+            completion.finish()
         }
         
-        XCTAssertEqual(queue.waiting.count, 0)
+        XCTAssertEqual(queue.count, 0)
         XCTAssertEqual(calls, [1, 2])
         
         queue.isQueuingForReorderEvent = true
@@ -51,10 +51,10 @@ class ListChangesQueueTests : XCTestCase {
         queue.add { completion in
             calls += [5]
             
-            completion.finished()
+            completion.finish()
         }
         
-        XCTAssertEqual(queue.waiting.count, 3)
+        XCTAssertEqual(queue.count, 3)
         XCTAssertEqual(calls, [1, 2])
         
         queue.isQueuingForReorderEvent = false
@@ -63,7 +63,7 @@ class ListChangesQueueTests : XCTestCase {
         XCTAssertFalse(queue.isQueuingForReorderEvent)
         
         waitFor {
-            queue.waiting.count == 0
+            queue.isEmpty
         }
         
         XCTAssertEqual(calls, [1, 2, 3, 4, 5])
@@ -92,7 +92,7 @@ class ListChangesQueueTests : XCTestCase {
         }
         
         XCTAssertEqual(calls, [1, 2, 3, 4])
-        XCTAssertEqual(queue.waiting.count, 0)
+        XCTAssertEqual(queue.count, 0)
     }
     
     
@@ -111,7 +111,7 @@ class ListChangesQueueTests : XCTestCase {
             calls += [1]
         
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
-                completion.finished()
+                completion.finish()
             }
         }
         
@@ -121,7 +121,7 @@ class ListChangesQueueTests : XCTestCase {
             calls += [2]
             
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(66)) {
-                completion.finished()
+                completion.finish()
             }
         }
         
@@ -131,7 +131,7 @@ class ListChangesQueueTests : XCTestCase {
             calls += [3]
             
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(33)) {
-                completion.finished()
+                completion.finish()
             }
         }
         
@@ -142,7 +142,7 @@ class ListChangesQueueTests : XCTestCase {
             
             calls += [4]
             
-            completion.finished()
+            completion.finish()
         }
         
         waitFor {
@@ -150,7 +150,7 @@ class ListChangesQueueTests : XCTestCase {
         }
         
         waitFor {
-            queue.waiting.count == 0
+            queue.isEmpty
         }
     }
     
@@ -171,7 +171,7 @@ class ListChangesQueueTests : XCTestCase {
             calls += [2]
         
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
-                completion.finished()
+                completion.finish()
             }
         }
         
@@ -183,7 +183,7 @@ class ListChangesQueueTests : XCTestCase {
             calls += [4]
             
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(66)) {
-                completion.finished()
+                completion.finish()
             }
         }
         
@@ -195,7 +195,7 @@ class ListChangesQueueTests : XCTestCase {
             calls += [6]
             
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(33)) {
-                completion.finished()
+                completion.finish()
             }
         }
         
@@ -206,7 +206,7 @@ class ListChangesQueueTests : XCTestCase {
         queue.add { completion in
             calls += [8]
             
-            completion.finished()
+            completion.finish()
         }
         
         queue.add {
@@ -218,7 +218,7 @@ class ListChangesQueueTests : XCTestCase {
         }
         
         waitFor {
-            queue.waiting.count == 0
+            queue.isEmpty
         }
     }
     
@@ -243,7 +243,7 @@ class ListChangesQueueTests : XCTestCase {
                     calls += [value]
                 
                     DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(2)) {
-                        completion.finished()
+                        completion.finish()
                     }
                 }
             }
@@ -252,13 +252,13 @@ class ListChangesQueueTests : XCTestCase {
                 queue.add { completion in
                     calls += [value]
                 
-                    completion.finished()
+                    completion.finish()
                 }
             }
         }
         
         waitFor {
-            queue.waiting.isEmpty
+            queue.isEmpty
         }
         
         XCTAssertEqual(

--- a/ListableUI/Tests/XCTestCaseAdditions.swift
+++ b/ListableUI/Tests/XCTestCaseAdditions.swift
@@ -10,6 +10,53 @@ import XCTest
 
 extension XCTestCase
 {
+    ///
+    /// Call this method to show a view controller in the test host application
+    /// during a unit test. The view controller will be the size of host application's device.
+    ///
+    /// After the test runs, the view controller will be removed from the view hierarchy.
+    ///
+    /// A test failure will occur if the host application does not exist, or does not have a root view controller.
+    ///
+    public func show<ViewController: UIViewController>(
+        vc viewController: ViewController,
+        loadAndPlaceView: Bool = true,
+        test: (ViewController) throws -> Void
+    ) rethrows {
+
+        guard let rootVC = UIApplication.shared.delegate?.window??.rootViewController else {
+            XCTFail("Cannot present a view controller in a test host that does not have a root window.")
+            return
+        }
+
+        rootVC.addChild(viewController)
+        viewController.didMove(toParent: rootVC)
+
+        if loadAndPlaceView {
+            viewController.view.frame = rootVC.view.bounds
+            viewController.view.layoutIfNeeded()
+
+            rootVC.beginAppearanceTransition(true, animated: false)
+            rootVC.view.addSubview(viewController.view)
+            rootVC.endAppearanceTransition()
+        }
+
+        defer {
+            if loadAndPlaceView {
+                viewController.beginAppearanceTransition(false, animated: false)
+                viewController.view.removeFromSuperview()
+                viewController.endAppearanceTransition()
+            }
+
+            viewController.willMove(toParent: nil)
+            viewController.removeFromParent()
+        }
+
+        try autoreleasepool {
+            try test(viewController)
+        }
+    }
+    
     func testcase(_ name : String = "", _ block : () -> ())
     {
         block()


### PR DESCRIPTION
This fixes an issue where, it seems like, in some cases, `performBatchUpdates(_:completion:)` will call its update block non-synchronously – which means if multiple updates end up getting submitted in quick succession; the latter update can end up in an invalid state and crash. The fix is to ensure we queue critical update work in our updates queue. The primary changes here are in `ListChangesQueue` and `ListView`.

### Checklist

Please do the following before merging:

- [ ] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
