### PR TITLE
Scroll Insets: Cleanup iOS 13 deprecation warning

### DIFF
--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -308,20 +308,24 @@ public final class ListView : UIView, KeyboardObserverDelegate
         
     private func updateScrollViewInsets()
     {
-        let (contentInsets, scrollIndicatorInsets) = self.calculateScrollViewInsets(
+        let insets = self.calculateScrollViewInsets(
             with: self.keyboardObserver.currentFrame(in: self)
         )
         
-        if self.collectionView.contentInset != contentInsets {
-            self.collectionView.contentInset = contentInsets
+        if self.collectionView.contentInset != insets.content {
+            self.collectionView.contentInset = insets.content
         }
         
-        if self.collectionView.scrollIndicatorInsets != scrollIndicatorInsets {
-            self.collectionView.scrollIndicatorInsets = scrollIndicatorInsets
+        if self.collectionView.horizontalScrollIndicatorInsets != insets.horizontalScroll {
+            self.collectionView.horizontalScrollIndicatorInsets = insets.horizontalScroll
+        }
+
+        if self.collectionView.verticalScrollIndicatorInsets != insets.verticalScroll {
+            self.collectionView.verticalScrollIndicatorInsets = insets.verticalScroll
         }
     }
-    
-    func calculateScrollViewInsets(with keyboardFrame : KeyboardObserver.KeyboardFrame?) -> (UIEdgeInsets, UIEdgeInsets)
+
+    func calculateScrollViewInsets(with keyboardFrame : KeyboardObserver.KeyboardFrame?) -> (content: UIEdgeInsets, horizontalScroll: UIEdgeInsets, verticalScroll: UIEdgeInsets)
     {
         let keyboardBottomInset : CGFloat = {
             
@@ -347,8 +351,8 @@ public final class ListView : UIView, KeyboardObserverDelegate
                 }
             }
         }()
-        
-        let scrollIndicatorInsets = modified(self.scrollIndicatorInsets) {
+
+        let scrollInsets = modified(self.scrollIndicatorInsets) {
             $0.bottom = max($0.bottom, keyboardBottomInset)
         }
         
@@ -356,7 +360,21 @@ public final class ListView : UIView, KeyboardObserverDelegate
             $0.bottom = keyboardBottomInset
         }
         
-        return (contentInsets, scrollIndicatorInsets)
+        return (
+            content: contentInsets,
+            horizontalScroll: UIEdgeInsets(
+                top: 0,
+                left: scrollInsets.left,
+                bottom: 0,
+                right: scrollInsets.right
+            ),
+            verticalScroll: UIEdgeInsets(
+                top: scrollInsets.top,
+                left: 0,
+                bottom: scrollInsets.bottom,
+                right: 0
+            )
+        )
     }
     
     //

--- a/ListableUI/Tests/ListView/ListViewTests.swift
+++ b/ListableUI/Tests/ListView/ListViewTests.swift
@@ -18,14 +18,14 @@ class ListViewTests: XCTestCase
         // Verify that there's no retain cycles within the list,
         // by making a list, putting content in it, and then waiting
         // for the list to be deallocated by testing a weak pointer.
-        
+
         weak var weakList : ListView? = nil
-        
+
         autoreleasepool {
             var listView : ListView? = ListView(frame: CGRect(x: 0, y: 0, width: 200, height: 400))
-            
+
             listView?.configure { list in
-                
+
                 list.header = TestSupplementary()
                 list.footer = TestSupplementary()
                 list.overscrollFooter = TestSupplementary()
@@ -33,7 +33,7 @@ class ListViewTests: XCTestCase
                 list("content") { section in
                     section.header = TestSupplementary()
                     section.footer = TestSupplementary()
-                    
+
                     section += TestContent(content: "1")
                     section += TestContent(content: "2")
                     section += TestContent(content: "3")
@@ -41,144 +41,160 @@ class ListViewTests: XCTestCase
             }
 
             self.waitForOneRunloop()
-            
+
             weakList = listView
-            
+
             listView = nil
         }
-        
+
         self.waitFor {
             weakList == nil
         }
     }
-    
+
     func test_changing_supplementary_views()
     {
         // Ensure that we can swap out a supplementary view without any other changes.
         // Before nesting the supplementary views provided by the developer in a container
         // view that is always present, this code would crash because the collection
         // view does not know to refresh the views.
-        
+
         let listView = ListView(frame: CGRect(x: 0, y: 0, width: 200, height: 400))
-                
+
         listView.configure { list in
             list.animatesChanges = false
-            
+
             list += Section("a-section")
             list.content.overscrollFooter = TestSupplementary()
         }
-        
+
         listView.collectionView.contentOffset.y = 100
         self.waitForOneRunloop()
-        
+
         listView.configure { list in
             list.animatesChanges = false
-            
+
             list += Section("a-section")
             list.content.overscrollFooter = nil
         }
-        
+
         listView.collectionView.contentOffset.y = 100
         self.waitForOneRunloop()
-        
+
         listView.configure { list in
             list.animatesChanges = false
-            
+
             list += Section("a-section")
             list.content.overscrollFooter = TestSupplementary()
         }
-        
+
         listView.collectionView.contentOffset.y = 100
         self.waitForOneRunloop()
     }
-    
+
     func test_calculateScrollViewInsets()
     {
         let listView = ListView(frame: CGRect(x: 0, y: 0, width: 200, height: 400))
-        
+
         listView.scrollIndicatorInsets = UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
-        
+
         self.testcase("Nil Keyboard Frame") {
-            let (content, scroll) = listView.calculateScrollViewInsets(with: nil)
-            
+            let insets = listView.calculateScrollViewInsets(with: nil)
+
             XCTAssertEqual(
-                content,
+                insets.content,
                 UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
             )
-            
+
             XCTAssertEqual(
-                scroll,
-                UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
+                insets.horizontalScroll,
+                UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 40)
             )
+
+            XCTAssertEqual(
+                insets.verticalScroll,
+                UIEdgeInsets(top: 10, left: 0, bottom: 30, right: 0)
+            )
+
         }
-        
+
         self.testcase("Non-Overlapping Keyboard Frame") {
-            let (content, scroll) = listView.calculateScrollViewInsets(with: .nonOverlapping)
-            
+            let insets = listView.calculateScrollViewInsets(with: .nonOverlapping)
+
             XCTAssertEqual(
-                content,
+                insets.content,
                 UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
             )
-            
+
             XCTAssertEqual(
-                scroll,
-                UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
+                insets.horizontalScroll,
+                UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 40)
+            )
+
+            XCTAssertEqual(
+                insets.verticalScroll,
+                UIEdgeInsets(top: 10, left: 0, bottom: 30, right: 0)
             )
         }
-        
+
         self.testcase("Overlapping Keyboard Frame") {
-            let (content, scroll) = listView.calculateScrollViewInsets(
+            let insets = listView.calculateScrollViewInsets(
                 with:.overlapping(frame: CGRect(x: 0, y: 200, width: 200, height: 200))
             )
-            
+
             XCTAssertEqual(
-                content,
+                insets.content,
                 UIEdgeInsets(top: 0, left: 0, bottom: 200, right: 0)
             )
-            
+
             XCTAssertEqual(
-                scroll,
-                UIEdgeInsets(top: 10, left: 20, bottom: 200, right: 40)
+                insets.horizontalScroll,
+                UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 40)
+            )
+
+            XCTAssertEqual(
+                insets.verticalScroll,
+                UIEdgeInsets(top: 10, left: 0, bottom: 200, right: 0)
             )
         }
     }
-    
+
     func test_change_size() {
-        
+
         /// Ensure we respect the size of the view changing via both bounds and frame.
         /// Frame is usually used via manual layout or Blueprint, whereas bounds is
         /// set by autolayout if a developer is using autolayout.
-        
+
         self.testcase("set bounds") {
             let view = ListView()
             view.bounds.size = CGSize(width: 200, height: 200)
-            
+
             XCTAssertEqual(view.collectionView.bounds.size, CGSize(width: 200, height: 200))
         }
-        
+
         self.testcase("set frame") {
             let view = ListView()
             view.frame.size = CGSize(width: 200, height: 200)
-            
+
             XCTAssertEqual(view.collectionView.bounds.size, CGSize(width: 200, height: 200))
         }
     }
-    
+
     func test_changing_to_empty_frame_does_not_crash() {
-        
+
         let view = ListView()
         view.frame.size = CGSize(width: 200, height: 400)
-        
+
         view.configure { list in
-            
+
             for section in 1...5 {
-                
+
                 list(section) { section in
                     section.header = HeaderFooter(
                         TestSupplementary(),
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     for row in 1...10 {
                         section += Item(
                             TestContent(content: row),
@@ -188,10 +204,10 @@ class ListViewTests: XCTestCase
                 }
             }
         }
-        
+
         /// Force the cells in the collection view to be updated.
         view.collectionView.layoutIfNeeded()
-        
+
         /// Changing the view width to an empty size removes content
         /// from the inner collection view, because laying out content
         /// with zero area is meaningless.
@@ -200,22 +216,22 @@ class ListViewTests: XCTestCase
         /// because the collection view layout's `visibleLayoutAttributesForElements`
         /// had not yet updated, leaving us with invalid index paths.
         view.frame.size.width = 0.0
-        
+
         view.collectionView.layoutIfNeeded()
-        
+
         view.frame.size.width = 200
-        
+
         view.collectionView.layoutIfNeeded()
     }
-    
+
     func test_reappliesToVisibleView() {
-        
+
         self.testcase("always") {
             let view = ListView()
             view.frame.size = CGSize(width: 200, height: 400)
-            
+
             var reappliedIDs = [AnyHashable]()
-            
+
             view.configure { list in
                 list("section") { section in
                     section.header = HeaderFooter(
@@ -224,21 +240,21 @@ class ListViewTests: XCTestCase
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section.footer = HeaderFooter(
                         ReapplySupplementary1(title: "footer", reappliesToVisibleView: .always) {
                             reappliedIDs.append("footer1")
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section += Item(
                         ReapplyContent(title: "row", id: 1, reappliesToVisibleView: .always) {
                             reappliedIDs.append(1)
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section += Item(
                         ReapplyContent(title: "row", id: 2, reappliesToVisibleView: .always)  {
                             reappliedIDs.append(2)
@@ -247,19 +263,19 @@ class ListViewTests: XCTestCase
                     )
                 }
             }
-            
+
             /// Force the cells in the collection view to be updated.
             view.collectionView.layoutIfNeeded()
-            
+
             XCTAssertEqual(reappliedIDs, [
                 1,
                 2,
                 "header1",
                 "footer1",
             ])
-            
+
             reappliedIDs.removeAll()
-            
+
             view.configure { list in
                 list("section") { section in
                     section.header = HeaderFooter(
@@ -268,21 +284,21 @@ class ListViewTests: XCTestCase
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section.footer = HeaderFooter(
                         ReapplySupplementary1(title: "footer", reappliesToVisibleView: .always) {
                             reappliedIDs.append("footer1")
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section += Item(
                         ReapplyContent(title: "row", id: 1, reappliesToVisibleView: .always) {
                             reappliedIDs.append(1)
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section += Item(
                         ReapplyContent(title: "row", id: 2, reappliesToVisibleView: .always)  {
                             reappliedIDs.append(2)
@@ -291,10 +307,10 @@ class ListViewTests: XCTestCase
                     )
                 }
             }
-            
+
             /// Force the cells in the collection view to be updated.
             view.collectionView.layoutIfNeeded()
-            
+
             XCTAssertEqual(reappliedIDs, [
                 "header1",
                 "footer1",
@@ -302,13 +318,13 @@ class ListViewTests: XCTestCase
                 2
             ])
         }
-        
+
         self.testcase("ifNotEquivalent") {
             let view = ListView()
             view.frame.size = CGSize(width: 200, height: 400)
-            
+
             var reappliedIDs = [AnyHashable]()
-            
+
             view.configure { list in
                 list("section") { section in
                     section.header = HeaderFooter(
@@ -317,21 +333,21 @@ class ListViewTests: XCTestCase
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section.footer = HeaderFooter(
                         ReapplySupplementary1(title: "footer", reappliesToVisibleView: .ifNotEquivalent) {
                             reappliedIDs.append("footer1")
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section += Item(
                         ReapplyContent(title: "row", id: 1, reappliesToVisibleView: .ifNotEquivalent) {
                             reappliedIDs.append(1)
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section += Item(
                         ReapplyContent(title: "row", id: 2, reappliesToVisibleView: .ifNotEquivalent)  {
                             reappliedIDs.append(2)
@@ -340,19 +356,19 @@ class ListViewTests: XCTestCase
                     )
                 }
             }
-            
+
             /// Force the cells in the collection view to be updated.
             view.collectionView.layoutIfNeeded()
-            
+
             XCTAssertEqual(reappliedIDs, [
                 1,
                 2,
                 "header1",
                 "footer1",
             ])
-            
+
             reappliedIDs.removeAll()
-            
+
             view.configure { list in
                 list("section") { section in
                     section.header = HeaderFooter(
@@ -361,21 +377,21 @@ class ListViewTests: XCTestCase
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section.footer = HeaderFooter(
                         ReapplySupplementary1(title: "changed footer", reappliesToVisibleView: .ifNotEquivalent) {
                             reappliedIDs.append("footer1")
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section += Item(
                         ReapplyContent(title: "row", id: 1, reappliesToVisibleView: .ifNotEquivalent) {
                             reappliedIDs.append(1)
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section += Item(
                         ReapplyContent(title: "changed row", id: 2, reappliesToVisibleView: .ifNotEquivalent)  {
                             reappliedIDs.append(2)
@@ -384,19 +400,19 @@ class ListViewTests: XCTestCase
                     )
                 }
             }
-            
+
             /// Force the cells in the collection view to be updated.
             view.collectionView.layoutIfNeeded()
-            
+
             XCTAssertEqual(reappliedIDs, [
                 "footer1",
                 2
             ])
-            
+
             /// Ensure we can also safely swap out the header and footer kinds.
-            
+
             reappliedIDs.removeAll()
-            
+
             view.configure { list in
                 list("section") { section in
                     section.header = HeaderFooter(
@@ -405,7 +421,7 @@ class ListViewTests: XCTestCase
                         },
                         sizing: .fixed(height: 50)
                     )
-                    
+
                     section.footer = HeaderFooter(
                         ReapplySupplementary2(title: "footer", reappliesToVisibleView: .ifNotEquivalent) {
                             reappliedIDs.append("footer2")
@@ -414,102 +430,102 @@ class ListViewTests: XCTestCase
                     )
                 }
             }
-            
+
             /// Force the cells in the collection view to be updated.
             view.collectionView.layoutIfNeeded()
-            
+
             XCTAssertEqual(reappliedIDs, [
                 "header2",
                 "footer2",
             ])
-            
+
             /// ... Or just remove all the content.
-            
+
             reappliedIDs.removeAll()
-            
+
             view.configure { list in
                 /// Intentionally empty.
             }
-            
+
             /// Force the cells in the collection view to be updated.
             view.collectionView.layoutIfNeeded()
-            
+
             XCTAssertEqual(reappliedIDs, [])
         }
     }
-    
+
     func test_content_context() {
-        
+
         let view = ListView()
         view.frame.size = CGSize(width: 200, height: 400)
-        
+
         func configure(list : inout ListProperties) {
             list.header = HeaderFooter(
                 ReapplySupplementary1(title: "title", reappliesToVisibleView: .ifNotEquivalent) {},
                 sizing: .fixed(height: 50)
             )
-            
+
             list.footer = HeaderFooter(
                 ReapplySupplementary1(title: "title", reappliesToVisibleView: .ifNotEquivalent) {},
                 sizing: .fixed(height: 50)
             )
-            
+
             list("section") { section in
                 section.header = HeaderFooter(
                     ReapplySupplementary1(title: "title", reappliesToVisibleView: .ifNotEquivalent) {},
                     sizing: .fixed(height: 50)
                 )
-                
+
                 section.footer = HeaderFooter(
                     ReapplySupplementary1(title: "changed footer", reappliesToVisibleView: .ifNotEquivalent) {},
                     sizing: .fixed(height: 50)
                 )
-                
+
                 section += Item(
                     ReapplyContent(title: "row", id: 1, reappliesToVisibleView: .ifNotEquivalent) {},
                     sizing: .fixed(height: 50)
                 )
             }
         }
-     
+
         view.configure { list in
-            
+
             list.context = ContentContext(false)
-            
+
             configure(list: &list)
         }
-        
+
         /// Force the cells in the collection view to be updated.
         view.collectionView.layoutIfNeeded()
-        
+
         var didResetSizesCount = 0
-        
+
         view.storage.presentationState.onResetCachedSizes = {
             didResetSizesCount += 1
         }
-        
+
         // Do it twice, should only be called once since the value is the same.
 
         for _ in 1...2 {
             view.configure { list in
-                
+
                 list.context = ContentContext(true)
-                
+
                 configure(list: &list)
             }
         }
-        
+
         /// Force the cells in the collection view to be updated.
         view.collectionView.layoutIfNeeded()
-        
+
         XCTAssertEqual(didResetSizesCount, 1)
     }
-    
+
     /// An "integration" test that removes content from the list to verify we can round trip updates properly.
     func test_delete_all_content() {
-                
+
         let base = Content { content in
-            
+
             for sectionID in 1...50 {
                 content += Section(sectionID) {
                     for itemID in 1...20 {
@@ -518,32 +534,32 @@ class ListViewTests: XCTestCase
                 }
             }
         }
-        
+
         let vc = ViewController()
-        
+
         show(vc: vc) { vc in
             var content = base
-            
+
             self.waitFor(timeout: 100) {
-             
+
                 vc.list.configure { list in
                     list.content = content
-                    
+
                     list.layout = .table {
                         $0.layout.itemSpacing = 10
                     }
                 }
-                
+
                 if var section = content.sections.popLast() {
                     section.items.removeLast()
-                    
+
                     if section.items.isEmpty == false {
                         content.add(section)
                     }
                 }
-                
+
                 vc.list.collectionView.layoutIfNeeded()
-                
+
                 return content.sections.isEmpty
             }
         }
@@ -551,9 +567,9 @@ class ListViewTests: XCTestCase
 }
 
 fileprivate final class ViewController : UIViewController {
-    
+
     let list : ListView = ListView()
-    
+
     override func loadView() {
         self.view = list
     }
@@ -562,11 +578,11 @@ fileprivate final class ViewController : UIViewController {
 fileprivate struct TestContent : ItemContent, Equatable
 {
     var content : AnyHashable
-    
+
     var identifierValue: AnyHashable {
         self.content
     }
-    
+
     func apply(
         to views: ItemContentViews<Self>,
         for reason: ApplyReason,
@@ -574,14 +590,14 @@ fileprivate struct TestContent : ItemContent, Equatable
     ) {
         views.content.backgroundColor = .red
     }
-    
+
     typealias ContentView = UIView
-    
+
     static func createReusableContentView(frame: CGRect) -> UIView
     {
         return UIView(frame: frame)
     }
-    
+
     var defaultItemProperties: DefaultProperties {
         .defaults { defaults in
             defaults.sizing = .fixed(height: 50)
@@ -599,7 +615,7 @@ fileprivate struct TestSupplementary : HeaderFooterContent, Equatable
     ) {
         views.content.backgroundColor = .blue
     }
-    
+
     typealias ContentView = UIView
 
     static func createReusableContentView(frame: CGRect) -> UIView
@@ -613,15 +629,15 @@ fileprivate struct ReapplyContent : ItemContent
 {
     var title : String
     var id : AnyHashable
-    
+
     func isEquivalent(to other: ReapplyContent) -> Bool {
         self.title == other.title
     }
-    
+
     var identifierValue: AnyHashable {
         self.id
     }
-    
+
     func apply(
         to views: ItemContentViews<Self>,
         for reason: ApplyReason,
@@ -631,16 +647,16 @@ fileprivate struct ReapplyContent : ItemContent
             self.onApply()
         }
     }
-    
+
     typealias ContentView = UIView
-    
+
     static func createReusableContentView(frame: CGRect) -> UIView
     {
         return UIView(frame: frame)
     }
-    
+
     var reappliesToVisibleView: ReappliesToVisibleView
-    
+
     var onApply : () -> ()
 }
 
@@ -648,11 +664,11 @@ fileprivate struct ReapplyContent : ItemContent
 fileprivate struct ReapplySupplementary1 : HeaderFooterContent
 {
     var title : String
-    
+
     func isEquivalent(to other: Self) -> Bool {
         self.title == other.title
     }
-    
+
     func apply(
         to views: HeaderFooterContentViews<Self>,
         for reason: ApplyReason,
@@ -662,16 +678,16 @@ fileprivate struct ReapplySupplementary1 : HeaderFooterContent
             self.onApply()
         }
     }
-    
+
     typealias ContentView = UIView
 
     static func createReusableContentView(frame: CGRect) -> UIView
     {
         return UIView(frame: frame)
     }
-    
+
     var reappliesToVisibleView: ReappliesToVisibleView
-    
+
     var onApply : () -> ()
 }
 
@@ -679,11 +695,11 @@ fileprivate struct ReapplySupplementary1 : HeaderFooterContent
 fileprivate struct ReapplySupplementary2 : HeaderFooterContent
 {
     var title : String
-    
+
     func isEquivalent(to other: Self) -> Bool {
         self.title == other.title
     }
-    
+
     func apply(
         to views: HeaderFooterContentViews<Self>,
         for reason: ApplyReason,
@@ -693,15 +709,15 @@ fileprivate struct ReapplySupplementary2 : HeaderFooterContent
             self.onApply()
         }
     }
-    
+
     typealias ContentView = UIView
 
     static func createReusableContentView(frame: CGRect) -> UIView
     {
         return UIView(frame: frame)
     }
-    
+
     var reappliesToVisibleView: ReappliesToVisibleView
-    
+
     var onApply : () -> ()
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/square/Blueprint",
         "state": {
           "branch": null,
-          "revision": "6364f64580255696c49ff03eea781a5f90d2d639",
-          "version": "0.45.0"
+          "revision": "2d07bc87c96d2413914eba6c28c169c4268e8abc",
+          "version": "0.47.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -59,8 +59,8 @@ let package = Package(
             dependencies: ["ListableUI", "EnglishDictionary", "Snapshot"],
             path: "ListableUI/Tests",
             exclude: [
+                "Layout/Flow/Snapshot Results",
                 "Layout/Paged/Snapshot Results",
-                "Layout/Retail Grid/Snapshot Results",
                 "Layout/Table/Snapshot Results",
                 "Previews/Snapshot Results",
             ],


### PR DESCRIPTION
This changes the use of `collectionView.scollIndicatorInsets` to the paired horizontal and vertical scroll insets.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
