### PR TITLE
[Demo] Incorporate collapsible nested accordion view in demo app

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		0AEB96B922FBCBA600341DFF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0AEB96B822FBCBA600341DFF /* Assets.xcassets */; };
 		0AEB96BC22FBCBA600341DFF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0AEB96BA22FBCBA600341DFF /* LaunchScreen.storyboard */; };
 		0AEB96E222FBCC1D00341DFF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEB96D322FBCC1D00341DFF /* AppDelegate.swift */; };
+		0E24EF24295359B50049EB6F /* NestedAccordionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E24EF23295359B50049EB6F /* NestedAccordionViewController.swift */; };
 		1F46FB6B26010F4900760961 /* RefreshControlOffsetAdjustmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F46FB6A26010F4900760961 /* RefreshControlOffsetAdjustmentViewController.swift */; };
 		27B4DCE9244F88BE001BA9D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 27B4DCE8244F88BE001BA9D9 /* Assets.xcassets */; };
 		2B56913A2846737C00E575BE /* AutoScrollingViewController2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5691392846737C00E575BE /* AutoScrollingViewController2.swift */; };
@@ -99,6 +100,7 @@
 		0AEB96BB22FBCBA600341DFF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		0AEB96BD22FBCBA600341DFF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0AEB96D322FBCC1D00341DFF /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		0E24EF23295359B50049EB6F /* NestedAccordionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedAccordionViewController.swift; sourceTree = "<group>"; };
 		1F46FB6A26010F4900760961 /* RefreshControlOffsetAdjustmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshControlOffsetAdjustmentViewController.swift; sourceTree = "<group>"; };
 		27B4DCE8244F88BE001BA9D9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2B5691392846737C00E575BE /* AutoScrollingViewController2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoScrollingViewController2.swift; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 				0AA4D9AE248064A300CF95A5 /* WidthCustomizationViewController.swift */,
 				0AC839A425EEAD110055CEF5 /* OnTapItemAnimationViewController.swift */,
 				2B5691392846737C00E575BE /* AutoScrollingViewController2.swift */,
+				0E24EF23295359B50049EB6F /* NestedAccordionViewController.swift */,
 			);
 			path = "Demo Screens";
 			sourceTree = "<group>";
@@ -478,6 +481,7 @@
 				0AA4D9BC248064A300CF95A5 /* KeyboardTestingViewController.swift in Sources */,
 				0AA4D9C1248064A300CF95A5 /* CoordinatorViewController.swift in Sources */,
 				0A49210424E5E11300D17038 /* AccordionViewController.swift in Sources */,
+				0E24EF24295359B50049EB6F /* NestedAccordionViewController.swift in Sources */,
 				0A1306E7272F29B300F6DDDD /* BestPractices.swift in Sources */,
 				0AA4D9C3248064A300CF95A5 /* CollectionViewAppearance.swift in Sources */,
 				2B8804652490844A003BB351 /* SpacingCustomizationViewController.swift in Sources */,

--- a/Demo/Sources/Demos/Demo Screens/NestedAccordionViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/NestedAccordionViewController.swift
@@ -1,0 +1,187 @@
+//
+//  NestedAccordionViewController.swift
+//  Demo
+//
+//  Created by Will on 12/21/22.
+//  Copyright © 2022 Will Li. All rights reserved.
+//
+
+import BlueprintUILists
+import BlueprintUICommonControls
+
+/// Abstraction of the data model used for the nested hierarchy structure in nested accordion UI.
+fileprivate protocol RowTreeModel {
+
+    var name: String { get }
+
+    func getChildren() -> [Self]
+}
+
+/// Data model that represents an item category to be used in the nested accordion.
+fileprivate struct CategoryModel: RowTreeModel {
+
+    let name: String
+
+    let children: [Child]
+
+    enum Child {
+        case model(CategoryModel)
+    }
+
+    func getChildren() -> [Self] {
+        children.map {
+            switch $0 {
+            case .model(let model):
+                return model
+            }
+        }
+    }
+}
+
+/// View model for the nested hierarchy structure.
+fileprivate class RowTree<Model: RowTreeModel> {
+
+    typealias OnTap = () -> Void
+
+    var isExpanded : Bool
+
+    let onTap: OnTap
+
+    let model: Model
+
+    let children : [RowTree<Model>]
+
+    func render(atDepth depth: Int) -> [AnyItem] {
+        let item = Item(IndentedAccordionRow(text: model.name, indentLevel: depth),
+                        selectionStyle: .selectable(isSelected: self.isExpanded),
+                        onSelect: { selected in
+                            self.isExpanded = true
+                            self.onTap()
+                        }, onDeselect: { deselected in
+                            self.isExpanded = false
+                            self.onTap()
+                        })
+
+        return [item] + (isExpanded ? self.children.flatMap { $0.render(atDepth: depth + 1) } : [])
+    }
+
+    init(_ model: Model, onTap: @escaping OnTap) {
+        self.isExpanded = false
+        self.onTap = onTap
+        self.model = model
+        self.children = model.getChildren().map {
+            .init($0, onTap: onTap)
+        }
+    }
+}
+
+/// View controller for the nested accordion view.
+final class NestedAccordionViewController : ListViewController
+{
+    private var selectedIndex : Int? = nil
+
+    private var viewModel: [RowTree<CategoryModel>] = []
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.viewModel = toViewModel()
+    }
+
+    override func configure(list: inout ListProperties) {
+        list.behavior.selectionMode = .multiple
+
+        #if false
+        list.stateObserver.onSelectionChanged { change in
+            print("Selection Changed from \(change.old) to \(change.new).")
+        }
+        #endif
+
+        list("content") { section in
+            section += self.viewModel
+                            .enumerated()
+                            .map { idx, rowTree in
+                                rowTree.render(atDepth: 1)
+                            }
+                            .flatMap { $0 }
+        }
+    }
+
+    private func toViewModel() -> [RowTree<CategoryModel>] {
+        categories.map { RowTree($0, onTap: { [weak self] in
+            self?.reload(animated: true)
+        }) }
+    }
+}
+
+/// Row element in the nested accordion view.
+fileprivate struct IndentedAccordionRow : BlueprintItemContent, Equatable
+{
+    let text : String
+    let indentLevel: Int
+
+    var identifierValue: String {
+        self.text
+    }
+    
+    func element(with info: ApplyItemContentInfo) -> Element {
+        Label(text: self.text) {
+            $0.alignment = .left
+            $0.font = .systemFont(ofSize: 16.0, weight: .semibold)
+        }
+        .inset(top: 10.0, bottom: 10.0, left: 30.0 * CGFloat(indentLevel), right: 20.0)
+        .constrainedTo(height: .atLeast(60.0))
+    }
+    
+    func backgroundElement(with info: ApplyItemContentInfo) -> Element? {
+        Overlay(
+            elements: [
+                Box(backgroundColor: .white),
+                Box(backgroundColor: .init(white: 0.90, alpha: 1.0))
+                    .constrainedTo(height: .absolute(1.0))
+                    .aligned(vertically: .bottom, horizontally: .fill)
+            ]
+        )
+    }
+
+    #if false
+    func selectedBackgroundElement(with info: ApplyItemContentInfo) -> Element? {
+        Box(backgroundColor: .white(0.8), cornerStyle: .rounded(radius: 15.0))
+    }
+    #endif
+}
+
+// Sample model data
+fileprivate let categories: [CategoryModel] = [
+    CategoryModel(name: "Fall/Winter 2022", children: [
+        .model(CategoryModel(name: "Men", children: [])),
+        .model(CategoryModel(name: "Women", children: [])),
+        .model(CategoryModel(name: "Accessories", children: [
+            .model(CategoryModel(name: "Scarf", children: [])),
+            .model(CategoryModel(name: "Gloves", children: [])),
+            .model(CategoryModel(name: "Hat", children: [])),
+        ])),
+    ]),
+    CategoryModel(name: "Ready to Wear", children: [
+        .model(CategoryModel(name: "Coats", children: [])),
+        .model(CategoryModel(name: "Shirts", children: [
+            .model(CategoryModel(name: "Long sleeve", children: [])),
+            .model(CategoryModel(name: "Short sleeve", children: [])),
+            .model(CategoryModel(name: "Sweathshirts", children: [])),
+        ])),
+        .model(CategoryModel(name: "Pants", children: [])),
+    ]),
+    CategoryModel(name: "Shoes", children: [
+        .model(CategoryModel(name: "Running shoes", children: [])),
+        .model(CategoryModel(name: "Others", children: [
+            .model(CategoryModel(name: "Running shoes", children: [
+                .model(CategoryModel(name: "Casuals", children: [])),
+                .model(CategoryModel(name: "Air cushioned", children: [])),
+                .model(CategoryModel(name: "High performance", children: [])),
+            ])),
+            .model(CategoryModel(name: "High heels", children: [])),
+            .model(CategoryModel(name: "Hiking boots", children: [])),
+        ])),
+        .model(CategoryModel(name: "Winter boots", children: [])),
+    ]),
+    CategoryModel(name: "Bags", children: []),
+]

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -195,7 +195,15 @@ public final class DemosRootViewController : ListViewController
                         self?.push(AccordionViewController())
                     }
                 )
-                
+
+                Item(
+                    DemoItem(text: "Nested Accordion View"),
+                    selectionStyle: .tappable,
+                    onSelect: { _ in
+                        self?.push(NestedAccordionViewController())
+                    }
+                )
+
                 Item(
                     DemoItem(text: "Using Autolayout"),
                     selectionStyle: .selectable(),


### PR DESCRIPTION
I've implemented a collapsible accordion-style view for displaying hierarchical data. This was implemented as a proof-of-concept to validate the feasibility of implementing such UI for two of our iOS projects that incorporates such design. I thought it'd be a good idea to get this into the demo app.

![Listable_NestedAccordionView_Demo](https://user-images.githubusercontent.com/104791486/216647949-cb4f67f3-7340-42b5-8569-c1630415876f.gif)

### Checklist

Please do the following before merging:

- [ ] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
