### PR TITLE
Bump Blueprint to 0.49.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/square/Blueprint",
         "state": {
           "branch": null,
-          "revision": "0c5fcb410eefee8cbc2af9180c82c639fd0eda2f",
-          "version": "0.48.0"
+          "revision": "aa8d58757d91316e8c1c640a580e067342c36a4b",
+          "version": "0.49.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/square/Blueprint", from: "0.48.1"),
+        .package(url: "https://github.com/square/Blueprint", from: "0.49.0"),
     ],
     targets: [
         .target(

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - BlueprintUI (0.48.1)
-  - BlueprintUICommonControls (0.48.1):
-    - BlueprintUI (= 0.48.1)
+  - BlueprintUI (0.49.0)
+  - BlueprintUICommonControls (0.49.0):
+    - BlueprintUI (= 0.49.0)
   - BlueprintUILists (8.0.1):
-    - BlueprintUI (~> 0.48.0)
+    - BlueprintUI (~> 0.49.0)
     - ListableUI
   - BlueprintUILists/Tests (8.0.1):
-    - BlueprintUI (~> 0.48.0)
+    - BlueprintUI (~> 0.49.0)
     - BlueprintUICommonControls
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
@@ -44,9 +44,9 @@ EXTERNAL SOURCES:
     :path: Internal Pods/Snapshot/Snapshot.podspec
 
 SPEC CHECKSUMS:
-  BlueprintUI: 18c3ae5f3744831602423574e13fb1fa5e8c8a8d
-  BlueprintUICommonControls: 80db8cd1bd45e2d39d3c28d39ae9fcfe036d3aa4
-  BlueprintUILists: fb7aa4d4a1931b85f14349fc35623e8c4a5041cb
+  BlueprintUI: 890f6a44bcad754a537532ca6cbe479bc93c0267
+  BlueprintUICommonControls: 2b9559ab9c5a68fc05ac62c30be6a5f5fde68e79
+  BlueprintUILists: ec0a3dda37a46c93efb8a74be89882c5e872aa97
   EnglishDictionary: 277ff15917abc170362afbd2ad11cbe15c2ae6ad
   ListableUI: bb78382479e58b06a99c1e40eeb869fad7b33f0f
   Snapshot: a936e73ede9570c80fb55e20542903e81efbad82

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '0.48.0'
+BLUEPRINT_VERSION ||= '0.49.0'
 
 LISTABLE_VERSION ||= '8.0.1'
 


### PR DESCRIPTION
# [0.49.0](https://github.com/square/Blueprint/compare/0.48.1...0.49.0)

## Fixed

- Fixed unexpected measurement results that could occur from Images using the aspectFit contentMode.