### PR TITLE
weak self for a callback retained by a timer

### DIFF
--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -731,9 +731,9 @@ public final class ListView : UIView
             guard let self = self else { return }
             guard self.sourceChangedTimer == nil else { return }
             
-            self.sourceChangedTimer = ReloadTimer {
-                self.sourceChangedTimer = nil
-                self.setContentFromSource(animated: true)
+            self.sourceChangedTimer = ReloadTimer { [weak self] in
+                self?.sourceChangedTimer = nil
+                self?.setContentFromSource(animated: true)
             }
         })
         


### PR DESCRIPTION
`ListView` is a `class` that has an internal timer that fires when sources change.

This timer has a callback that is triggered when the timer fires.

In the callback, since `ListView` is a class, we ultimately capture a reference `self`.

Since a `Timer` will keep a strong reference to its target (a `ReloadTimer` instance) and the target of the timer owns the block that captures `self` we wind up in a situation where a list can be kept alive a runloop longer than expected.

This is pretty harmless in apps, but I saw some non-determinism when looking at the memory graph for some KIF integration tests that I think ultimately comes back to this `Timer`.

### Checklist

Please do the following before merging:

- [ ] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
