### PR TITLE
Update swipe action view style when style changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fixed an issue that could cause the wrong swipe action view style being applied when multiple styles were used in a single list.
+
 ### Added
 
 ### Removed

--- a/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
@@ -17,6 +17,8 @@ final class SwipeActionsViewController: UIViewController  {
     private var allowDeleting: Bool = true
 
     private var items = (0..<10).map { SwipeActionItem(isSaved: Bool.random(), identifier: $0) }
+    
+    private var customItems = (100..<110).map { SwipeActionItem(isSaved: Bool.random(), identifier: $0) }
 
     override func loadView() {
         self.title = "Swipe Actions"
@@ -52,7 +54,7 @@ final class SwipeActionsViewController: UIViewController  {
             }
 
             list += Section("standardSwipeActionItems") { section in
-                section.header = DemoHeader(title: "Standard Style Swipable Items")
+                section.header = DemoHeader(title: "Standard Style Swipeable Items")
                 section += self.items.map { item in
                     Item(
                         SwipeActionsDemoItem(item: item, swipeActionsStyle: .default),
@@ -62,8 +64,8 @@ final class SwipeActionsViewController: UIViewController  {
             }
 
             list += Section("customSwipeActionItems") { section in
-                section.header = DemoHeader(title: "Custom Style Swipable Items")
-                section += self.items.map { item in
+                section.header = DemoHeader(title: "Custom Style Swipeable Items")
+                section += self.customItems.map { item in
                     Item(
                         SwipeActionsDemoItem(
                             item: item,

--- a/ListableUI/Sources/Internal/DefaultSwipeView.swift
+++ b/ListableUI/Sources/Internal/DefaultSwipeView.swift
@@ -51,7 +51,14 @@ public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView 
 
     private var firstAction: SwipeAction?
     private var didPerformAction: SwipeAction.CompletionHandler
-    private let style: Style
+    
+    private var style: Style {
+        didSet {
+            if style != oldValue {
+                setNeedsLayout()
+            }
+        }
+    }
 
     public var swipeActionsWidth: CGFloat {
         calculatedNaturalWidth + safeAreaInsets.right
@@ -134,8 +141,12 @@ public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView 
         } + CGFloat(max(0, buttons.count - 1)) * style.interActionSpacing
     }
 
-    public func apply(actions: SwipeActionsConfiguration) {
-        if actionButtons.count != actions.actions.count {
+    public func apply(actions: SwipeActionsConfiguration, style: Style) {
+        let styleUpdateRequired = style != self.style
+        
+        self.style = style
+                
+        if actionButtons.count != actions.actions.count || styleUpdateRequired {
             actionButtons.forEach { $0.superview?.removeFromSuperview() }
             actionButtons = actions.actions.map { _ in
                 let button = DefaultSwipeActionButton()

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -128,7 +128,7 @@ extension ItemCell {
             }
 
             swipeConfiguration?.numberOfActions = actions.actions.count
-            swipeConfiguration?.swipeView.apply(actions: actions)
+            swipeConfiguration?.swipeView.apply(actions: actions, style: style)
             configureAccessibilityActions(for: actions.actions)
 
             if reason == .willDisplay {

--- a/ListableUI/Sources/Item/ItemContent.swift
+++ b/ListableUI/Sources/Item/ItemContent.swift
@@ -679,7 +679,7 @@ public protocol ItemContentSwipeActionsView: UIView {
 
     init(style: Style, didPerformAction: @escaping SwipeAction.CompletionHandler)
 
-    func apply(actions: SwipeActionsConfiguration)
+    func apply(actions: SwipeActionsConfiguration, style: Style)
 
     func apply(state: SwipeActionState)
 }


### PR DESCRIPTION
- Fixed an issue that could cause the wrong swipe action view style being applied when multiple styles were used in a single list.

Discovered in the demo:
<img width="1563" alt="image" src="https://user-images.githubusercontent.com/430436/228677601-b503b668-b8ba-4fce-8510-aeecc38c5a45.png">


### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
