### PR TITLE
Allow swipe action view style to be set via environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@
 ### Added
 
 - Added `containerCornerRadius`, `equalButtonWidths`, and `minWidth` to `DefaultSwipeActionsView.Style` for additional swipe action style customization.
+- Added `defaultSwipeActionsViewStyle` to `ListEnvironment`. This allows a `DefaultSwipeActionsView.Style` to be set on the environment when customizing the appearance of the default swipe action view.
+- Added `styleEnvironmentKey` to the `ItemContentSwipeActionsView` protocol. 
+- Added the `DefaultProviding` protocol for providing a default value for a type.
 
 ### Removed
 
 ### Changed
+
+- The type of the `ItemContent.swipeActionsStyle` protocol requirement is now `SwipeActionsView.Style?` (previously `SwipeActionsView.Style`).
+- `ItemContentSwipeActionsView.Style` must now conform to `DefaultProviding`.
 
 ### Misc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added `containerCornerRadius`, `equalButtonWidths`, and `minWidth` to `DefaultSwipeActionsView.Style` for additional swipe action style customization.
+
 ### Removed
 
 ### Changed

--- a/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
@@ -15,11 +15,13 @@ final class SwipeActionsViewController: UIViewController  {
     private let blueprintView = BlueprintView()
 
     private var allowDeleting: Bool = true
-
-    private var items = (0..<10).map { SwipeActionItem(isSaved: Bool.random(), identifier: $0) }
     
-    private var customItems = (100..<110).map { SwipeActionItem(isSaved: Bool.random(), identifier: $0) }
-
+    private var sections = (0..<2).map { _ in
+        (0..<10).map { _ in
+            SwipeActionItem(isSaved: Bool.random(), identifier: UUID().uuidString)
+        }
+    }
+    
     override func loadView() {
         self.title = "Swipe Actions"
 
@@ -50,14 +52,18 @@ final class SwipeActionsViewController: UIViewController  {
                     )
                 )
                 
-                $0.layout.itemSpacing = 8
+                $0.layout.itemSpacing = 4
             }
 
             list += Section("standardSwipeActionItems") { section in
                 section.header = DemoHeader(title: "Standard Style Swipeable Items")
-                section += self.items.map { item in
+                section += self.sections[0].map { item in
                     Item(
-                        SwipeActionsDemoItem(item: item, swipeActionsStyle: .default),
+                        SwipeActionsDemoItem(
+                            item: item,
+                            swipeActionsStyle: .default,
+                            mode: .roundedWithBorder
+                        ),
                         swipeActions: self.makeSwipeActions(for: item)
                     )
                 }
@@ -65,16 +71,17 @@ final class SwipeActionsViewController: UIViewController  {
 
             list += Section("customSwipeActionItems") { section in
                 section.header = DemoHeader(title: "Custom Style Swipeable Items")
-                section += self.customItems.map { item in
+                section += self.sections[1].map { item in
                     Item(
                         SwipeActionsDemoItem(
                             item: item,
                             swipeActionsStyle:
                                 .init(
-                                    actionShape: .rectangle(cornerRadius: 8),
-                                    interActionSpacing: 8,
-                                    containerInsets: .init(top: 8, left: 8, bottom: 8, right: 8)
-                                )
+                                    containerCornerRadius: 6,
+                                    equalButtonWidths: true,
+                                    minWidth: 80
+                                ),
+                            mode: .plain
                         ),
                         swipeActions: self.makeSwipeActions(for: item)
                     )
@@ -89,7 +96,7 @@ final class SwipeActionsViewController: UIViewController  {
             if allowDeleting {
                 SwipeAction(
                     title: "Delete",
-                    backgroundColor: .systemRed,
+                    backgroundColor: UIColor(red: 0.80, green: 0, blue: 0.137, alpha: 1.0),
                     image: nil
                 ) { [weak self] expandActions in
                     self?.confirmDelete(item: item, expandActions: expandActions)
@@ -98,8 +105,8 @@ final class SwipeActionsViewController: UIViewController  {
             
             SwipeAction(
                 title: item.isSaved ? "Unsave" : "Save",
-                backgroundColor: UIColor(displayP3Red: 0, green: 0.741, blue: 0.149, alpha: 1),
-                tintColor: UIColor(red: 0.1843, green: 0.4, blue: 0.1922, alpha: 1.0),
+                backgroundColor: .black.withAlphaComponent(0.05),
+                tintColor: UIColor(red: 0, green: 0.353, blue: 0.851, alpha: 1.0),
                 image: item.isSaved ? nil : UIImage(named: "bookmark")!.withRenderingMode(.alwaysTemplate)
             ) { [weak self] expandActions in
                 self?.toggleSave(item: item)
@@ -109,8 +116,8 @@ final class SwipeActionsViewController: UIViewController  {
     }
 
     @objc private func addItem() {
-        let identifier = (items.last?.identifier ?? -1) + 1
-        items.append(SwipeActionItem(isSaved: false, identifier: identifier))
+        let identifier = UUID().uuidString
+        sections[0].append(SwipeActionItem(isSaved: false, identifier: identifier))
         reloadData(animated: true)
     }
 
@@ -127,8 +134,12 @@ final class SwipeActionsViewController: UIViewController  {
         })
 
         alert.addAction(UIAlertAction(title: "Delete", style: .destructive) { [weak self] _ in
-            self?.items.removeAll(where: { $0 == item })
-            self?.reloadData(animated: true)
+            guard let self else { return }
+            
+            for i in self.sections.indices {
+                self.sections[i].removeAll(where: { $0.identifier == item.identifier })
+            }
+            self.reloadData(animated: true)
             expandActions(true)
         })
 
@@ -136,73 +147,87 @@ final class SwipeActionsViewController: UIViewController  {
     }
 
     private func toggleSave(item: SwipeActionItem) {
-        guard let index = items.firstIndex(of: item) else { return }
-        items[index].isSaved.toggle()
+        for i in sections.indices {
+            guard let index = sections[i].firstIndex(of: item) else { continue }
+            sections[i][index].isSaved.toggle()
+        }
         reloadData(animated: true)
-
     }
 
     struct SwipeActionsDemoItem: BlueprintItemContent, Equatable {
+        enum Mode {
+            case plain
+            case roundedWithBorder
+        }
+        
         var item: SwipeActionItem
         var swipeActionsStyle: DefaultSwipeActionsView.Style
+        var mode: Mode
 
-        var identifierValue: Int {
+        var identifierValue: String {
             self.item.identifier
         }
 
         func overlayDecorationElement(with info: ApplyItemContentInfo) -> Element? {
-            Empty()
-                .box(background: .clear, corners: .rounded(radius: 6), borders: .solid(color: .black, width: 2))
+            switch mode {
+            case .plain:
+                return nil
+            case .roundedWithBorder:
+                return Empty()
+                    .box(background: .clear, corners: .rounded(radius: 6), borders: .solid(color: .black, width: 2))
+            }
         }
         
         func contentAreaViewProperties(with info: ApplyItemContentInfo) -> ViewProperties {
-            .init(clipsToBounds: true, cornerStyle: .rounded(radius: 6))
+            switch mode {
+            case .plain:
+                return .init()
+            case .roundedWithBorder:
+                return .init(clipsToBounds: true, cornerStyle: .rounded(radius: 6))
+            }
         }
         
         func backgroundElement(with info: ApplyItemContentInfo) -> Element? {
-            Empty()
-                .box(
-                    background: .white,
-                    corners: .rounded(radius: 6),
-                    shadow: .simple(
-                        radius: 3,
-                        opacity: 0.2,
-                        offset: .init(width: 0, height: 2),
-                        color: .black
+            switch mode {
+            case .plain:
+                return nil
+            case .roundedWithBorder:
+                return Empty()
+                    .box(
+                        background: .white,
+                        corners: .rounded(radius: 6),
+                        shadow: .simple(
+                            radius: 3,
+                            opacity: 0.2,
+                            offset: .init(width: 0, height: 2),
+                            color: .black
+                        )
                     )
-                )
+            }
         }
         
         func element(with info : ApplyItemContentInfo) -> Element {
-            return Column { column in
-
-                column.horizontalAlignment = .fill
-
-                let row = Row { row in
-
-                    row.minimumHorizontalSpacing = 8
-                    row.horizontalUnderflow = .spaceEvenly
-                    row.verticalAlignment = .center
-                    row.add(child: Label(text: self.item.title))
-
+            return Column(alignment: .fill) {
+                Row(alignment: .center, underflow: .spaceEvenly, minimumSpacing: 8) {
+                    Column {
+                        Label(text: "Item")
+                        Label(
+                            text: self.item.title,
+                            configure: { label in
+                                label.font = .systemFont(ofSize: 10)
+                            }
+                        )
+                    }
+                    
                     let bookmark = UIImage(named: "bookmark")!
                     
                     if item.isSaved {
-                        var image = Image(image: bookmark)
-                        image.contentMode = .center
-                        row.add(child: image)
+                        Image(image: bookmark, contentMode: .center)
                     } else {
-                        let spacer = Spacer(size: bookmark.size)
-                        row.add(child: spacer)
+                        Spacer(size: bookmark.size)
                     }
                 }
-
-                let inset = Inset(uniformInset: 16, wrapping: row)
-                column.add(child: inset)
-
-                let color = UIColor(displayP3Red: 0.725, green: 0.729, blue: 0.741, alpha: 1)
-                let separator = Inset(left: 16, wrapping: Rule(orientation: .horizontal, color: color))
-                column.add(growPriority: 0, shrinkPriority: 0, child: separator)
+                .inset(uniform: 16)
             }
             .accessibilityElement(label: "Swipeable Item", value: item.title, traits: [.button])
         }
@@ -210,8 +235,8 @@ final class SwipeActionsViewController: UIViewController  {
 
     struct SwipeActionItem: Equatable, Hashable {
         var isSaved: Bool
-        var identifier: Int
+        var identifier: String
 
-        var title: String { "Item #\(identifier)" }
+        var title: String { identifier }
     }
 }

--- a/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
@@ -61,13 +61,16 @@ final class SwipeActionsViewController: UIViewController  {
                     Item(
                         SwipeActionsDemoItem(
                             item: item,
-                            swipeActionsStyle: .default,
                             mode: .roundedWithBorder
                         ),
                         swipeActions: self.makeSwipeActions(for: item)
                     )
                 }
             }
+            
+            // The style can be customized at the environment level via
+            // `list.environment.defaultSwipeActionsViewStyle` or at the content level
+            // as demonstrated below.
 
             list += Section("customSwipeActionItems") { section in
                 section.header = DemoHeader(title: "Custom Style Swipeable Items")
@@ -161,7 +164,7 @@ final class SwipeActionsViewController: UIViewController  {
         }
         
         var item: SwipeActionItem
-        var swipeActionsStyle: DefaultSwipeActionsView.Style
+        var swipeActionsStyle: DefaultSwipeActionsView.Style?
         var mode: Mode
 
         var identifierValue: String {

--- a/ListableUI/Sources/Internal/DefaultSwipeView.swift
+++ b/ListableUI/Sources/Internal/DefaultSwipeView.swift
@@ -7,11 +7,26 @@
 
 import UIKit
 
+extension ListEnvironment {
+    
+    public var defaultSwipeActionsViewStyle : DefaultSwipeActionsView.Style? {
+        get { self[DefaultSwipeActionsViewStyleKey.self] }
+        set { self[DefaultSwipeActionsViewStyleKey.self] = newValue }
+    }
+}
+
+public enum DefaultSwipeActionsViewStyleKey: ListEnvironmentKey {
+    
+    public static var defaultValue: DefaultSwipeActionsView.Style? {
+        return nil
+    }
+}
+
 private let haptics = UIImpactFeedbackGenerator(style: .light)
 
 public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView {
 
-    public struct Style: Equatable {
+    public struct Style: Equatable, DefaultProviding {
         public enum Shape: Equatable {
             case rectangle(cornerRadius: CGFloat)
         }
@@ -47,6 +62,10 @@ public final class DefaultSwipeActionsView: UIView, ItemContentSwipeActionsView 
                 return cornerRadius
             }
         }
+    }
+    
+    public static var styleEnvironmentKey: (any ListEnvironmentKey.Type)? {
+        return DefaultSwipeActionsViewStyleKey.self
     }
 
     private var actionButtons: [DefaultSwipeActionButton] = []

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
@@ -313,7 +313,11 @@ extension PresentationState
                         
             // Apply Swipe To Action Appearance
             if let actions = self.model.swipeActions {
-                cell.contentContainer.registerSwipeActionsIfNeeded(actions: actions, style: model.content.swipeActionsStyle, reason: reason)
+                cell.contentContainer.registerSwipeActionsIfNeeded(
+                    actions: actions,
+                    style: resolvedSwipeActionViewStyle(in: environment),
+                    reason: reason
+                )
             } else {
                 cell.contentContainer.deregisterSwipeIfNeeded()
             }
@@ -571,6 +575,17 @@ extension PresentationState
         }
         
         private(set) var activeReorderEventInfo : ActiveReorderEventInfo? = nil
+        
+        func resolvedSwipeActionViewStyle(in environment: ListEnvironment) -> Content.SwipeActionsView.Style {
+            if let contentStyle = model.content.swipeActionsStyle {
+                return contentStyle
+            } else if let environmentKey = Content.SwipeActionsView.styleEnvironmentKey,
+                      let environmentStyle = environment[environmentKey] as? Content.SwipeActionsView.Style {
+                return environmentStyle
+            } else {
+                return Content.SwipeActionsView.Style.default
+            }
+        }
     }
 }
 

--- a/ListableUI/Sources/Item/ItemContent.swift
+++ b/ListableUI/Sources/Item/ItemContent.swift
@@ -357,8 +357,11 @@ public protocol ItemContent : AnyItemConvertible where Coordinator.ItemContentTy
     /// A default implementation, which matches `UITableView`, is provided.
     associatedtype SwipeActionsView: ItemContentSwipeActionsView = DefaultSwipeActionsView
 
-    /// Specify a swipe action style for this content.
-    var swipeActionsStyle: SwipeActionsView.Style { get }
+    /// The swipe action style for this content.
+    ///
+    /// If this is `nil`, the style specified in the environment will be used (if available) or else
+    /// the `SwipeActionsView.Style.default` will be used.
+    var swipeActionsStyle: SwipeActionsView.Style? { get }
 
     //
     // MARK: Creating & Providing Content Views
@@ -532,9 +535,9 @@ public struct ApplyItemContentInfo
     public var environment : ListEnvironment
 }
 
-public extension ItemContent where SwipeActionsView.Style == DefaultSwipeActionsView.Style {
-    var swipeActionsStyle: SwipeActionsView.Style {
-        return .default
+public extension ItemContent {
+    var swipeActionsStyle: SwipeActionsView.Style? {
+        return nil
     }
 }
 
@@ -673,7 +676,12 @@ public extension ItemContent where OverlayDecorationView == UIView
 /// as well as updating the layout based on the swipe state.
 public protocol ItemContentSwipeActionsView: UIView {
     /// Swipe action styles (e.g. `standard`, `grouped`, etc.) that are supported by the view.
-    associatedtype Style: Equatable
+    associatedtype Style: Equatable, DefaultProviding
+    
+    /// The environment key used to fetch style information from the environment.
+    ///
+    /// The default implementation returns `nil`.
+    static var styleEnvironmentKey: (any ListEnvironmentKey.Type)? { get }
 
     var swipeActionsWidth: CGFloat { get }
 
@@ -682,4 +690,16 @@ public protocol ItemContentSwipeActionsView: UIView {
     func apply(actions: SwipeActionsConfiguration, style: Style)
 
     func apply(state: SwipeActionState)
+}
+
+extension ItemContentSwipeActionsView {
+    static var styleEnvironmentKey: (any ListEnvironmentKey.Type)? {
+        return nil
+    }
+}
+
+public protocol DefaultProviding {
+    
+    /// A default value for this type.
+    static var `default`: Self { get }
 }


### PR DESCRIPTION
- Added `defaultSwipeActionsViewStyle` to `ListEnvironment`. This allows a `DefaultSwipeActionsView.Style` to be set on the environment when customizing the appearance of the default swipe action view.
- Added `styleEnvironmentKey` to the `ItemContentSwipeActionsView` protocol. 
- Added the `DefaultProviding` protocol for providing a default value for a type.
- The type of the `ItemContent.swipeActionsStyle` protocol requirement is now `SwipeActionsView.Style?` (previously `SwipeActionsView.Style`).
- `ItemContentSwipeActionsView.Style` must now conform to `DefaultProviding`.

This is a bit funky given how we allow each item to specify it's own `SwipeActionsView` type. You may want to start review at `PresentationState.ItemState.swift` to see how the style is resolved and work backwards from there. Open to other approaches, of course.

### Usage

```swift
list.environment.defaultSwipeActionsViewStyle = .init(
    containerCornerRadius: 6,
    equalButtonWidths: true,
    minWidth: 80
)
```

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
