### PR TITLE
Register callbacks for drag begin and deceleration end events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- Introduce `ListStateObserver.onDidEndDeceleration(_:)` callback, which allows an observer to become notified when the scrollview finishes deceleration.
+- Introduce `ListStateObserver.OnDidBeginDrag(_:)` callback, which allows an observer to become notified when the scrollview will begin dragging.
+
 ### Removed
 
 ### Changed

--- a/Demo/Sources/Demos/Demo Screens/ListStateViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ListStateViewController.swift
@@ -35,6 +35,14 @@ final class ListStateViewController : ListViewController
                 print("Did Scroll")
             }
             
+            observer.onBeginDrag { info in
+                print("Will Begin Drag")
+            }
+            
+            observer.onDidEndDeceleration { info in
+                print("Did End Deceleration")
+            }
+            
             observer.onVisibilityChanged { info in
                 print("Displayed: \(info.displayed.map { $0.anyIdentifier })")
                 print("Ended Display: \(info.endedDisplay.map { $0.anyIdentifier })")

--- a/ListableUI/Sources/ListStateObserver.swift
+++ b/ListableUI/Sources/ListStateObserver.swift
@@ -68,6 +68,34 @@ public struct ListStateObserver {
     private(set) var onDidScroll : [OnDidScroll] = []
     
     //
+    // MARK: Responding to Scrolling Deceleration
+    //
+    
+    public typealias OnDidEndDeceleration = (DidEndDeceleration) -> ()
+    
+    /// Registers a callback which will be called when the list view is finished decelerating.
+    public mutating func onDidEndDeceleration( _ callback : @escaping OnDidEndDeceleration)
+    {
+        self.onDidEndDeceleration.append(callback)
+    }
+    
+    private(set) var onDidEndDeceleration: [OnDidEndDeceleration] = []
+    
+    //
+    // MARK: Responding to Drag Begin
+    //
+    
+    public typealias OnBeginDrag = (BeginDrag) -> ()
+    
+    /// Registers a callback which will be called when the list view will begin dragging.
+    public mutating func onBeginDrag( _ callback: @escaping OnBeginDrag)
+    {
+        self.onBeginDrag.append(callback)
+    }
+    
+    private(set) var onBeginDrag: [OnBeginDrag] = []
+    
+    //
     // MARK: Responding To Content Updates
     //
     
@@ -184,6 +212,15 @@ extension ListStateObserver
         public let positionInfo : ListScrollPositionInfo
     }
     
+    /// Parameters available for ``OnDidEndDeceleration`` callbacks.
+    public struct DidEndDeceleration {
+        public let positionInfo : ListScrollPositionInfo
+    }
+    
+    /// Parameters available for ``OnBeginDrag`` callbacks.
+    public struct BeginDrag {
+        public let positionInfo : ListScrollPositionInfo
+    }
     
     /// Parameters available for ``OnContentUpdated`` callbacks.
     public struct ContentUpdated {

--- a/ListableUI/Sources/ListView/ListView.Delegate.swift
+++ b/ListableUI/Sources/ListView/ListView.Delegate.swift
@@ -298,11 +298,23 @@ extension ListView
             self.view.liveCells.perform {
                 $0.closeSwipeActions()
             }
+            
+            ListStateObserver.perform(self.view.stateObserver.onBeginDrag, "Will Begin Drag", with: self.view) { _ in
+                ListStateObserver.BeginDrag(
+                    positionInfo: self.view.scrollPositionInfo
+                )
+            }
         }
         
         func scrollViewDidEndDecelerating(_ scrollView: UIScrollView)
         {
             self.view.updatePresentationState(for: .didEndDecelerating)
+            
+            ListStateObserver.perform(self.view.stateObserver.onDidEndDeceleration, "Did End Deceleration", with: self.view) { _ in
+                ListStateObserver.DidEndDeceleration(
+                    positionInfo: self.view.scrollPositionInfo
+                )
+            }
         }
                 
         func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool


### PR DESCRIPTION
This PR introduces two public callbacks available on `ListStateObserver` for observing drag begin and drag end events.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
