### PR TITLE
Use accessibility label on swipe action if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Swipe actions will now use the `accessibilityLabel` (if non-nil) when the user is using assistive technologies such as VoiceOver.
+
 ### Added
 
 - Added `containerCornerRadius`, `equalButtonWidths`, and `minWidth` to `DefaultSwipeActionsView.Style` for additional swipe action style customization.

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -331,7 +331,10 @@ private class AccessibilitySwipeAction: UIAccessibilityCustomAction {
     init(action: SwipeAction, side: Side, target: Any?, selector: Selector) {
         self.action = action
         self.side = side
-        super.init(name: action.title ?? "", target: target, selector: selector)
+        
+        let name = action.accessibilityLabel ?? action.title ?? ""
+        
+        super.init(name: name, target: target, selector: selector)
     }
 }
 


### PR DESCRIPTION
- Swipe actions will now use the `accessibilityLabel` (if non-nil) when the user is using assistive technologies such as VoiceOver.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
