### PR TITLE
Leading and trailing container insets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `swipeActionsViewStyle` to `ListEnvironment`. This allows a `SwipeActionsView.Style` to be set on the list environment when customizing the appearance of the swipe action view.
 - Added the ability to configure leading swipe actions on `Item`s.
 - Added `containerCornerRadius`, `buttonSizing`, `minWidth`, and `maxWidthRatio` to `DefaultSwipeActionsView.Style` for additional swipe action style customization.
+- Added `SwipeActionsView.Style.leadingContainerInsets` to specify container insets for the leading swipe action container.
 
 ### Removed
 
@@ -20,6 +21,7 @@
 - The type of the `ItemContent.swipeActionsStyle` protocol requirement is now `SwipeActionsView.Style?` (previously `SwipeActionsView.Style`). When an item returns `nil` for this property the style set on the list environment will be used instead.
 - Renamed `Item.swipeActions` to `Item.leadingSwipeActions`.
 - Renamed `DefaultItemProperties.swipeActions` to `leadingSwipeActions`.
+- Renamed `SwipeActionsView.Style.containerInsets` to `SwipeActionsView.Style.trailingContainerInsets` and changed the type to `NSDirectionalEdgeInsets`.
 
 ### Misc
 


### PR DESCRIPTION
> **Note**
> This is targeting the `robmaceachern/feature/swipe-action-updates` branch

- Renamed `SwipeActionsView.Style.containerInsets` to `SwipeActionsView.Style.trailingContainerInsets` and changed the type to `NSDirectionalEdgeInsets`.
- Added `SwipeActionsView.Style.leadingContainerInsets` to specify container insets for the leading swipe action container.

I made the switch to `NSDirectionalEdgeInsets` because it allows clients to more accurately express their intent and will avoid changes if right-to-left support is eventually needed.

Here's what it looks like this style applied:

```
                list.environment.swipeActionsViewStyle = SwipeActionsView.Style(
                    leadingContainerInsets: NSDirectionalEdgeInsets(
                        top: 0,
                        leading: 0,
                        bottom: 0,
                        trailing: styles.spacings.spacing100
                    ),
                    trailingContainerInsets: NSDirectionalEdgeInsets(
                        top: 0,
                        leading: styles.spacings.spacing100,
                        bottom: 0,
                        trailing: 0
                    ),
                    containerCornerRadius: 6,
                    buttonSizing: .equalWidth,
                    minWidth: 80
                )
```

https://user-images.githubusercontent.com/430436/234111308-9e138d93-81df-40be-9360-b588829685b4.mp4


### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
