### PR TITLE
Standalone swipe actions style and internal `SwipeActionsView` type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Added `containerCornerRadius`, `equalButtonWidths`, and `minWidth` to `DefaultSwipeActionsView.Style` for additional swipe action style customization.
 - Added `swipeActionsViewStyle` to `ListEnvironment`. This allows a `SwipeActionsView.Style` to be set on the list environment when customizing the appearance of the swipe action view.
-- Added the ability to configure leading swipe actions on `Item`s.
+- Added the ability to configure leading swipe actions on `Item`s via the `leadingSwipeActions` property.
 - Added `containerCornerRadius`, `buttonSizing`, `minWidth`, and `maxWidthRatio` to `DefaultSwipeActionsView.Style` for additional swipe action style customization.
 - Added `SwipeActionsView.Style.leadingContainerInsets` to specify container insets for the leading swipe action container.
 
@@ -21,8 +21,8 @@
 
 - Renamed `DefaultSwipeActionsView` to `SwipeActionsView`.
 - The type of the `ItemContent.swipeActionsStyle` protocol requirement is now `SwipeActionsView.Style?` (previously `SwipeActionsView.Style`). When an item returns `nil` for this property the style set on the list environment will be used instead.
-- Renamed `Item.swipeActions` to `Item.leadingSwipeActions`.
-- Renamed `DefaultItemProperties.swipeActions` to `leadingSwipeActions`.
+- Renamed `Item.swipeActions` to `Item.trailingSwipeActions`.
+- Renamed `DefaultItemProperties.swipeActions` to `trailingSwipeActions`.
 - Renamed `SwipeActionsView.Style.containerInsets` to `SwipeActionsView.Style.trailingContainerInsets` and changed the type to `NSDirectionalEdgeInsets`.
 - Renamed `SwipeActionsView.Style` to `SwipeActionsViewStyle`.
 - `SwipeActionsView` and `SwipeActionState` are no longer public types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - Renamed `Item.swipeActions` to `Item.leadingSwipeActions`.
 - Renamed `DefaultItemProperties.swipeActions` to `leadingSwipeActions`.
 - Renamed `SwipeActionsView.Style.containerInsets` to `SwipeActionsView.Style.trailingContainerInsets` and changed the type to `NSDirectionalEdgeInsets`.
+- Renamed `SwipeActionsView.Style` to `SwipeActionsViewStyle`.
+- `SwipeActionsView` and `SwipeActionState` are no longer public types.
 
 ### Misc
 

--- a/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
@@ -236,7 +236,7 @@ final class SwipeActionsViewController: UIViewController  {
         }
         
         var item: SwipeActionItem
-        var swipeActionsStyle: SwipeActionsView.Style?
+        var swipeActionsStyle: SwipeActionsViewStyle?
         var mode: Mode
 
         var identifierValue: String {

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -132,18 +132,18 @@ extension ItemCell {
             deregisterSwipeIfNeeded(for: .right)
         }
         
-        func registerLeadingSwipeActionsIfNeeded(actions: SwipeActionsConfiguration, style: SwipeActionsView.Style, reason: ApplyReason) {
+        func registerLeadingSwipeActionsIfNeeded(actions: SwipeActionsConfiguration, style: SwipeActionsViewStyle, reason: ApplyReason) {
             registerSwipeActionsIfNeeded(side: .left, actions: actions, style: style, reason: reason)
         }
         
-        func registerTrailingSwipeActionsIfNeeded(actions: SwipeActionsConfiguration, style: SwipeActionsView.Style, reason: ApplyReason) {
+        func registerTrailingSwipeActionsIfNeeded(actions: SwipeActionsConfiguration, style: SwipeActionsViewStyle, reason: ApplyReason) {
             registerSwipeActionsIfNeeded(side: .right, actions: actions, style: style, reason: reason)
         }
         
         private func registerSwipeActionsIfNeeded(
             side: SwipeActionsView.Side,
             actions: SwipeActionsConfiguration,
-            style: SwipeActionsView.Style,
+            style: SwipeActionsViewStyle,
             reason: ApplyReason
         ) {
             if configurations[side] == nil {

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -339,8 +339,8 @@ private class AccessibilitySwipeAction: UIAccessibilityCustomAction {
 }
 
 /// These states dictate the layout of the swipe actions.
-public enum SwipeActionState: Equatable {
-    public typealias Side = SwipeActionsView.Side
+enum SwipeActionState: Equatable {
+    typealias Side = SwipeActionsView.Side
     
     /// The actions are completely collapsed.
     case closed

--- a/ListableUI/Sources/Internal/SwipeActionsView.swift
+++ b/ListableUI/Sources/Internal/SwipeActionsView.swift
@@ -16,74 +16,6 @@ public final class SwipeActionsView: UIView {
         case right
     }
 
-    public struct Style: Equatable {
-        public enum Shape: Equatable {
-            case rectangle(cornerRadius: CGFloat)
-        }
-        
-        /// The button sizing algorithm used when laying out swipe actions.
-        public enum ButtonSizing {
-            /// Each button button will lay out with an equal width based on the widest button.
-            /// - Note: If the total width of all buttons exceeds the available width, each button 
-            /// will be scaled down equally to fit.
-            case equalWidth
-            
-            /// Each button receives the amount of space required to fit its contents.
-            /// - Note: If the total width exceeds the available width, the buttons _will not_
-            // be scaled down to fit.
-            case sizeThatFits
-        }
-
-        public static let `default` = Style()
-
-        public var actionShape: Shape
-        public var interActionSpacing: CGFloat
-        
-        /// The insets to apply to the leading swipe actions container.
-        public var leadingContainerInsets: NSDirectionalEdgeInsets
-        
-        /// The insets to apply to the trailing swipe actions container.
-        public var trailingContainerInsets: NSDirectionalEdgeInsets
-        
-        public var containerCornerRadius: CGFloat
-        public var buttonSizing: ButtonSizing
-        public var minWidth: CGFloat
-        
-        /// The percentage of the row content width that is available for laying out swipe action buttons.
-        ///
-        /// For example, a value of `0.8` represents that the swipe action buttons should occupy no more than
-        /// 80% of the row content width when the swipe actions are opened.
-        /// - Note: Currently only applicable to `ButtonSizing.equalWidth` mode.
-        public var maxWidthRatio: CGFloat
-
-        public init(
-            actionShape: Shape = .rectangle(cornerRadius: 0),
-            interActionSpacing: CGFloat = 0,
-            leadingContainerInsets: NSDirectionalEdgeInsets = .zero,
-            trailingContainerInsets: NSDirectionalEdgeInsets = .zero,
-            containerCornerRadius: CGFloat = 0,
-            buttonSizing: ButtonSizing = .sizeThatFits,
-            minWidth: CGFloat = 0,
-            maxWidthRatio: CGFloat = 0.8
-        ) {
-            self.actionShape = actionShape
-            self.interActionSpacing = interActionSpacing
-            self.leadingContainerInsets = leadingContainerInsets
-            self.trailingContainerInsets = trailingContainerInsets
-            self.containerCornerRadius = containerCornerRadius
-            self.buttonSizing = buttonSizing
-            self.minWidth = minWidth
-            self.maxWidthRatio = maxWidthRatio
-        }
-
-        var cornerRadius: CGFloat {
-            switch actionShape {
-            case .rectangle(let cornerRadius):
-                return cornerRadius
-            }
-        }
-    }
-
     private var actionButtons: [DefaultSwipeActionButton] = []
     private let container: UIView = {
         let view = UIView()
@@ -96,7 +28,7 @@ public final class SwipeActionsView: UIView {
     private var firstAction: SwipeAction?
     private var didPerformAction: SwipeAction.CompletionHandler
     
-    private var style: Style {
+    private var style: SwipeActionsViewStyle {
         didSet {
             if style != oldValue {
                 setNeedsLayout()
@@ -127,7 +59,7 @@ public final class SwipeActionsView: UIView {
 
     public init(
         side: Side,
-        style: Style,
+        style: SwipeActionsViewStyle,
         didPerformAction: @escaping SwipeAction.CompletionHandler
     ) {
         self.side = side
@@ -260,7 +192,7 @@ public final class SwipeActionsView: UIView {
         return (CGFloat(max(0, numberOfButtons - 1)) * style.interActionSpacing)
     }
 
-    public func apply(actions: SwipeActionsConfiguration, style: Style) {
+    public func apply(actions: SwipeActionsConfiguration, style: SwipeActionsViewStyle) {
         let styleUpdateRequired = style != self.style
         
         self.style = style
@@ -368,22 +300,7 @@ private class DefaultSwipeActionButton: UIButton {
     }
 }
 
-extension ListEnvironment {
-    
-    public var swipeActionsViewStyle : SwipeActionsView.Style {
-        get { self[SwipeActionsViewStyleKey.self] }
-        set { self[SwipeActionsViewStyleKey.self] = newValue }
-    }
-}
-
-public enum SwipeActionsViewStyleKey: ListEnvironmentKey {
-    
-    public static var defaultValue: SwipeActionsView.Style {
-        .default
-    }
-}
-
-private extension SwipeActionsView.Style {
+private extension SwipeActionsViewStyle {
     
     /// The container insets to use for the given side and layout direction.
     func containerInsets(for side: SwipeActionsView.Side, layoutDirection: UIUserInterfaceLayoutDirection) -> UIEdgeInsets {
@@ -408,7 +325,7 @@ private extension SwipeActionsView.Style {
     }
 }
 
-extension NSDirectionalEdgeInsets {
+private extension NSDirectionalEdgeInsets {
     func edgeInsets(for layoutDirection: UIUserInterfaceLayoutDirection) -> UIEdgeInsets {
         switch layoutDirection {
         case .leftToRight:

--- a/ListableUI/Sources/Internal/SwipeActionsView.swift
+++ b/ListableUI/Sources/Internal/SwipeActionsView.swift
@@ -9,9 +9,9 @@ import UIKit
 
 private let haptics = UIImpactFeedbackGenerator(style: .light)
 
-public final class SwipeActionsView: UIView {
+final class SwipeActionsView: UIView {
     
-    public enum Side: Equatable {
+    enum Side: Equatable {
         case left
         case right
     }
@@ -36,7 +36,7 @@ public final class SwipeActionsView: UIView {
         }
     }
 
-    public var swipeActionsWidth: CGFloat {
+    var swipeActionsWidth: CGFloat {
         calculatedNaturalWidth + safeAreaInsets.right
     }
 
@@ -57,7 +57,7 @@ public final class SwipeActionsView: UIView {
         return UIView.userInterfaceLayoutDirection(for: semanticContentAttribute)
     }
 
-    public init(
+    init(
         side: Side,
         style: SwipeActionsViewStyle,
         didPerformAction: @escaping SwipeAction.CompletionHandler
@@ -75,7 +75,7 @@ public final class SwipeActionsView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func layoutSubviews() {
+    override func layoutSubviews() {
         super.layoutSubviews()
 
         let insets = style.containerInsets(for: side, layoutDirection: userInterfaceLayoutDirection)
@@ -192,7 +192,7 @@ public final class SwipeActionsView: UIView {
         return (CGFloat(max(0, numberOfButtons - 1)) * style.interActionSpacing)
     }
 
-    public func apply(actions: SwipeActionsConfiguration, style: SwipeActionsViewStyle) {
+    func apply(actions: SwipeActionsConfiguration, style: SwipeActionsViewStyle) {
         let styleUpdateRequired = style != self.style
         
         self.style = style
@@ -222,7 +222,7 @@ public final class SwipeActionsView: UIView {
         calculatedNaturalWidth = width(ofButtons: actionButtons) + containerInsets.left + containerInsets.right
     }
 
-    public func apply(state newState: SwipeActionState) {
+    func apply(state newState: SwipeActionState) {
         let priorState = state
         state = newState
         

--- a/ListableUI/Sources/Internal/SwipeActionsViewStyle.swift
+++ b/ListableUI/Sources/Internal/SwipeActionsViewStyle.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 public struct SwipeActionsViewStyle: Equatable {
     public enum Shape: Equatable {

--- a/ListableUI/Sources/Internal/SwipeActionsViewStyle.swift
+++ b/ListableUI/Sources/Internal/SwipeActionsViewStyle.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+public struct SwipeActionsViewStyle: Equatable {
+    public enum Shape: Equatable {
+        case rectangle(cornerRadius: CGFloat)
+    }
+    
+    /// The button sizing algorithm used when laying out swipe actions.
+    public enum ButtonSizing {
+        /// Each button button will lay out with an equal width based on the widest button.
+        /// - Note: If the total width of all buttons exceeds the available width, each button
+        /// will be scaled down equally to fit.
+        case equalWidth
+        
+        /// Each button receives the amount of space required to fit its contents.
+        /// - Note: If the total width exceeds the available width, the buttons _will not_
+        // be scaled down to fit.
+        case sizeThatFits
+    }
+
+    public static let `default` = SwipeActionsViewStyle()
+
+    public var actionShape: Shape
+    public var interActionSpacing: CGFloat
+    
+    /// The insets to apply to the leading swipe actions container.
+    public var leadingContainerInsets: NSDirectionalEdgeInsets
+    
+    /// The insets to apply to the trailing swipe actions container.
+    public var trailingContainerInsets: NSDirectionalEdgeInsets
+    
+    public var containerCornerRadius: CGFloat
+    public var buttonSizing: ButtonSizing
+    public var minWidth: CGFloat
+    
+    /// The percentage of the row content width that is available for laying out swipe action buttons.
+    ///
+    /// For example, a value of `0.8` represents that the swipe action buttons should occupy no more than
+    /// 80% of the row content width when the swipe actions are opened.
+    /// - Note: Currently only applicable to `ButtonSizing.equalWidth` mode.
+    public var maxWidthRatio: CGFloat
+
+    public init(
+        actionShape: Shape = .rectangle(cornerRadius: 0),
+        interActionSpacing: CGFloat = 0,
+        leadingContainerInsets: NSDirectionalEdgeInsets = .zero,
+        trailingContainerInsets: NSDirectionalEdgeInsets = .zero,
+        containerCornerRadius: CGFloat = 0,
+        buttonSizing: ButtonSizing = .sizeThatFits,
+        minWidth: CGFloat = 0,
+        maxWidthRatio: CGFloat = 0.8
+    ) {
+        self.actionShape = actionShape
+        self.interActionSpacing = interActionSpacing
+        self.leadingContainerInsets = leadingContainerInsets
+        self.trailingContainerInsets = trailingContainerInsets
+        self.containerCornerRadius = containerCornerRadius
+        self.buttonSizing = buttonSizing
+        self.minWidth = minWidth
+        self.maxWidthRatio = maxWidthRatio
+    }
+
+    var cornerRadius: CGFloat {
+        switch actionShape {
+        case .rectangle(let cornerRadius):
+            return cornerRadius
+        }
+    }
+}
+
+extension ListEnvironment {
+    
+    public var swipeActionsViewStyle : SwipeActionsViewStyle {
+        get { self[SwipeActionsViewStyleKey.self] }
+        set { self[SwipeActionsViewStyleKey.self] = newValue }
+    }
+}
+
+public enum SwipeActionsViewStyleKey: ListEnvironmentKey {
+    
+    public static var defaultValue: SwipeActionsViewStyle {
+        .default
+    }
+}

--- a/ListableUI/Sources/Item/ItemContent.swift
+++ b/ListableUI/Sources/Item/ItemContent.swift
@@ -356,7 +356,7 @@ public protocol ItemContent : AnyItemConvertible where Coordinator.ItemContentTy
     /// The swipe action style for this content.
     ///
     /// If this is `nil`, the style provided by the ``SwipeActionsViewStyleKey`` environment value will be used.
-    var swipeActionsStyle: SwipeActionsView.Style? { get }
+    var swipeActionsStyle: SwipeActionsViewStyle? { get }
 
     //
     // MARK: Creating & Providing Content Views
@@ -531,7 +531,7 @@ public struct ApplyItemContentInfo
 }
 
 public extension ItemContent {
-    var swipeActionsStyle: SwipeActionsView.Style? {
+    var swipeActionsStyle: SwipeActionsViewStyle? {
         return nil
     }
 }


### PR DESCRIPTION
> **Note**
> This is targeting the `robmaceachern/feature/swipe-action-updates` branch

- Renamed `SwipeActionsView.Style` to `SwipeActionsViewStyle` (and split into separate file).
- `SwipeActionsView` and `SwipeActionState` are no longer public types.

This is a follow up to [this comment](https://github.com/square/Listable/pull/473#discussion_r1173765070).

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
