### PR TITLE
Bump Blueprint dependency to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- BlueprintUILists now depends on Blueprint 2.0.
+
 ### Misc
 
 ### Internal

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/square/Blueprint",
         "state": {
           "branch": null,
-          "revision": "aa8d58757d91316e8c1c640a580e067342c36a4b",
-          "version": "0.49.0"
+          "revision": "3720f9556c954f875cc484eb0490651669fe6519",
+          "version": "2.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/square/Blueprint", from: "1.0.0"),
+        .package(url: "https://github.com/square/Blueprint", from: "2.0.0"),
     ],
     targets: [
         .target(

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - BlueprintUI (1.0.0)
-  - BlueprintUICommonControls (1.0.0):
-    - BlueprintUI (= 1.0.0)
+  - BlueprintUI (2.0.0)
+  - BlueprintUICommonControls (2.0.0):
+    - BlueprintUI (= 2.0.0)
   - BlueprintUILists (10.0.1):
-    - BlueprintUI (~> 1.0)
+    - BlueprintUI (~> 2.0)
     - ListableUI
   - BlueprintUILists/Tests (10.0.1):
-    - BlueprintUI (~> 1.0)
-    - BlueprintUICommonControls (~> 1.0)
+    - BlueprintUI (~> 2.0)
+    - BlueprintUICommonControls (~> 2.0)
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
   - ListableUI (10.0.1)
@@ -44,9 +44,9 @@ EXTERNAL SOURCES:
     :path: Internal Pods/Snapshot/Snapshot.podspec
 
 SPEC CHECKSUMS:
-  BlueprintUI: 91557907d6e9bd8d2fd9d1b7506c2a4cf388cc59
-  BlueprintUICommonControls: 3fe0b917e482c73959cb0061942aebdda4152a19
-  BlueprintUILists: 031f38d4afffafae0ed9135a76065022fca3c4fd
+  BlueprintUI: a1adeb91f76c88dd499ad693251aa96919b1c2a4
+  BlueprintUICommonControls: 9e02875bc6b8ef64aa9634c32d7156bd50c7b88d
+  BlueprintUILists: 6f11ef5103236185d6ebee124ef19b8163abff3a
   EnglishDictionary: 277ff15917abc170362afbd2ad11cbe15c2ae6ad
   ListableUI: 7dc9b7825358225c4c442c824815bdb497a16108
   Snapshot: a936e73ede9570c80fb55e20542903e81efbad82

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= ['~> 1.0'].freeze
+BLUEPRINT_VERSION ||= ['~> 2.0'].freeze
 
 LISTABLE_VERSION ||= '10.0.1'
 


### PR DESCRIPTION
From Blueprint changelog:

## 2.0.0 - 2023-05-02

### Fixed

- `ConstrainedAspectRatio`  measures correctly in `fitParent` and `fillParent` modes when the proposed constraint has the same aspect ratio as the element's constraint.
- `ConstrainedAspectRatio` adheres to the Caffeinated Layout contract when unconstrained in `fitParent` or `fillParent`, by reporting `infinity` instead of falling back to the constrained element's size.

### Changed

- Caffeinated Layout is enabled by default. You can disable it on a `BlueprintView` with the `layoutMode` property, or disable it globally by setting `LayoutMode.default`.

### Deprecated

- `ConstrainedAspectRatio` content mode `fillParent` is deprecated, due to having limited utility in Caffeinated Layout.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
