### PR TITLE
Added read-only dynamic member lookup support to ListProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fixed a confusing compilation error when omitting the `.content` property on read-only `KeyPath` lookups on `ListProperties`. 
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/ListProperties.swift
+++ b/ListableUI/Sources/ListProperties.swift
@@ -197,6 +197,31 @@ import UIKit
     }
     
     //
+    // MARK: Reading Content
+    //
+    
+    /// Allows directly reading properties on the list's `Content`, without having to explicitly specify
+    /// the `.content` component.
+    ///
+    /// Eg, you can now replace:
+    /// ```
+    /// ListProperties { list in
+    ///     ... = list.content.firstItem
+    ///     ... = list.content.lastItem
+    /// }
+    /// ```
+    /// With:
+    /// ```
+    /// ListProperties { list in
+    ///     ... = list.firstItem
+    ///     ... = list.lastItem
+    /// }
+    /// ```
+    public subscript<Value>(dynamicMember keyPath: KeyPath<Content, Value>) -> Value {
+        get { self.content[keyPath: keyPath] }
+    }
+    
+    //
     // MARK: Adding Content
     //
     
@@ -208,7 +233,6 @@ import UIKit
     /// ListProperties { list in
     ///     list.content.header = ...
     ///     list.content.footer = ...
-    ///     ...
     /// }
     /// ```
     /// With:
@@ -216,7 +240,6 @@ import UIKit
     /// ListProperties { list in
     ///     list.header = ...
     ///     list.footer = ...
-    ///     ...
     /// }
     /// ```
     public subscript<Value>(dynamicMember keyPath: WritableKeyPath<Content, Value>) -> Value {

--- a/ListableUI/Tests/ListPropertiesTests.swift
+++ b/ListableUI/Tests/ListPropertiesTests.swift
@@ -5,9 +5,37 @@
 //  Created by Kyle Van Essen on 11/27/19.
 //
 
+import ListableUI
 import XCTest
 
 class ListPropertiesTests : XCTestCase
 {
-
+    private func properties() -> ListProperties {
+        ListProperties(
+            animatesChanges: true,
+            layout: .flow(),
+            appearance: .init(),
+            scrollIndicatorInsets: .zero,
+            behavior: .init(),
+            autoScrollAction: .none,
+            accessibilityIdentifier: "",
+            debuggingIdentifier: "") { _ in }
+    }
+    
+    func test_read_only_dynamic_member_lookup() {
+        let properties = properties()
+        // Ensure that this compiles. Previously we were missing the read-only KeyPath
+        // dynamicMember subscript implementation which would lead to this error:
+        // Cannot assign to property: 'lastItem' is a get-only property
+        let item = properties.lastItem
+        XCTAssertNil(item)
+    }
+    
+    func test_writeable_dynamic_member_lookup() {
+        var properties = properties()
+        // Ensure that this compiles and writes through to the underlying content.
+        properties.identifier = "Hello"
+        XCTAssertEqual(properties.identifier, "Hello")
+        XCTAssertEqual(properties.identifier, properties.content.identifier)
+    }
 }


### PR DESCRIPTION
- Added read-only dynamic member lookup support to ListProperties.
- This fixes a confusing compilation error when omitting the `.content` property on read-only `KeyPath` lookups on `ListProperties`:

```
// Cannot assign to property: 'lastItem' is a get-only property
let item = properties.lastItem
```

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
