### PR TITLE
Added an underlay view to item cells

### DIFF
--- a/BlueprintUILists/Sources/BlueprintItemContent.swift
+++ b/BlueprintUILists/Sources/BlueprintItemContent.swift
@@ -59,7 +59,8 @@ public protocol BlueprintItemContent : ItemContent
     ContentView == BlueprintView,
     BackgroundView == BlueprintView,
     SelectedBackgroundView == BlueprintView,
-    OverlayDecorationView == BlueprintView
+    OverlayDecorationView == BlueprintView,
+    UnderlayDecorationView == BlueprintView
 {
     //
     // MARK: Creating Blueprint Element Representations
@@ -213,7 +214,7 @@ public extension BlueprintItemContent
         self.newBlueprintView(with: frame)
     }
     
-    static func createReusableUnderlayDecorationView(frame: CGRect) -> OverlayDecorationView {
+    static func createReusableUnderlayDecorationView(frame: CGRect) -> UnderlayDecorationView {
         self.newBlueprintView(with: frame)
     }
     

--- a/BlueprintUILists/Sources/BlueprintItemContent.swift
+++ b/BlueprintUILists/Sources/BlueprintItemContent.swift
@@ -101,6 +101,16 @@ public protocol BlueprintItemContent : ItemContent
     /// ### Note
     /// The default implementation of this method returns nil, and provides no decoration.
     func overlayDecorationElement(with info : ApplyItemContentInfo) -> Element?
+    
+    /// Optional. Create and return the Blueprint element used to represent the underlay decoration of the content.
+    /// The underlay decoration appears below all other content, and is not affected by swipe actions.
+    ///
+    /// You can use the provided `ApplyItemContentInfo` to vary the appearance of the element
+    /// based on the current state of the item.
+    ///
+    /// ### Note
+    /// The default implementation of this method returns nil, and provides no decoration.
+    func underlayDecorationElement(with info : ApplyItemContentInfo) -> Element?
 }
 
 
@@ -124,6 +134,11 @@ public extension BlueprintItemContent
     
     /// By default, content has no overlay decoration.
     func overlayDecorationElement(with info : ApplyItemContentInfo) -> Element? {
+        nil
+    }
+    
+    /// By default, content has no underlay decoration.
+    func underlayDecorationElement(with info : ApplyItemContentInfo) -> Element? {
         nil
     }
 }
@@ -170,6 +185,16 @@ public extension BlueprintItemContent
             /// If there's no element, clear out any past element, but only if the view was loaded.
             views.overlayDecorationIfLoaded?.element = nil
         }
+        
+        if let element = underlayDecorationElement(with: info)?
+            .wrapInBlueprintEnvironmentFrom(environment: info.environment)
+        {
+            /// Load the `underlayDecoration` view and assign our element update.
+            views.underlayDecoration.element = element
+        } else {
+            /// If there's no element, clear out any past element, but only if the view was loaded.
+            views.underlayDecorationIfLoaded?.element = nil
+        }
     }
     
     static func createReusableContentView(frame: CGRect) -> ContentView {
@@ -185,6 +210,10 @@ public extension BlueprintItemContent
     }
     
     static func createReusableOverlayDecorationView(frame: CGRect) -> OverlayDecorationView {
+        self.newBlueprintView(with: frame)
+    }
+    
+    static func createReusableUnderlayDecorationView(frame: CGRect) -> OverlayDecorationView {
         self.newBlueprintView(with: frame)
     }
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added optional underlay view for item cells that can be styled  
+
 ### Removed
 
 ### Changed

--- a/ListableUI/Sources/Internal/ItemCell.swift
+++ b/ListableUI/Sources/Internal/ItemCell.swift
@@ -42,6 +42,21 @@ final class ItemCell<Content:ItemContent> : UICollectionViewCell, AnyItemCell
     
     private(set) var overlayDecorationIfLoaded : OverlayDecorationView? = nil
     
+    private(set) lazy var underlayDecoration : OverlayDecorationView = {
+        let view = OverlayDecorationView(
+            content: Content.createReusableUnderlayDecorationView(frame:bounds),
+            frame: bounds
+        )
+        
+        self.underlayDecorationIfLoaded = view
+        
+        self.contentView.insertSubview(view, belowSubview: self.contentContainer)
+        
+        return view
+    }()
+    
+    private(set) var underlayDecorationIfLoaded : OverlayDecorationView? = nil
+    
     let contentContainer : ContentContainerView
 
     private(set) lazy var background : Content.BackgroundView = {
@@ -161,6 +176,7 @@ final class ItemCell<Content:ItemContent> : UICollectionViewCell, AnyItemCell
         self.contentContainer.frame = self.contentView.bounds
         
         self.overlayDecorationIfLoaded?.frame = self.contentView.bounds
+        self.underlayDecorationIfLoaded?.frame = self.contentView.bounds
     }
     
     // MARK: AnyItemCell

--- a/ListableUI/Sources/Internal/ItemCell.swift
+++ b/ListableUI/Sources/Internal/ItemCell.swift
@@ -42,8 +42,8 @@ final class ItemCell<Content:ItemContent> : UICollectionViewCell, AnyItemCell
     
     private(set) var overlayDecorationIfLoaded : OverlayDecorationView? = nil
     
-    private(set) lazy var underlayDecoration : OverlayDecorationView = {
-        let view = OverlayDecorationView(
+    private(set) lazy var underlayDecoration : UnderlayDecorationView = {
+        let view = UnderlayDecorationView(
             content: Content.createReusableUnderlayDecorationView(frame:bounds),
             frame: bounds
         )
@@ -55,7 +55,7 @@ final class ItemCell<Content:ItemContent> : UICollectionViewCell, AnyItemCell
         return view
     }()
     
-    private(set) var underlayDecorationIfLoaded : OverlayDecorationView? = nil
+    private(set) var underlayDecorationIfLoaded : UnderlayDecorationView? = nil
     
     let contentContainer : ContentContainerView
 
@@ -236,6 +236,45 @@ extension ItemCell {
         let content : Content.OverlayDecorationView
         
         init(content : Content.OverlayDecorationView, frame: CGRect) {
+            
+            self.content = content
+            
+            super.init(frame: frame)
+            
+            self.content.frame = bounds
+            self.addSubview(self.content)
+            
+            self.isUserInteractionEnabled = false
+        }
+        
+        @available(*, unavailable)
+        required init?(coder: NSCoder) { fatalError() }
+        
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            
+            self.content.frame = self.bounds
+        }
+        
+        override var isAccessibilityElement: Bool {
+            get { false }
+            set { fatalError("Cannot set isAccessibilityElement.") }
+        }
+        
+        override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+            false
+        }
+        
+        override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+            nil
+        }
+    }
+    
+    final class UnderlayDecorationView : UIView {
+        
+        let content : Content.UnderlayDecorationView
+        
+        init(content : Content.UnderlayDecorationView, frame: CGRect) {
             
             self.content = content
             

--- a/ListableUI/Sources/Internal/ItemCell.swift
+++ b/ListableUI/Sources/Internal/ItemCell.swift
@@ -27,8 +27,8 @@ protocol AnyItemCell : UICollectionViewCell
 ///
 final class ItemCell<Content:ItemContent> : UICollectionViewCell, AnyItemCell
 {
-    private(set) lazy var overlayDecoration : OverlayDecorationView = {
-        let view = OverlayDecorationView(
+    private(set) lazy var overlayDecoration : DecorationView<Content.OverlayDecorationView> = {
+        let view = DecorationView<Content.OverlayDecorationView>(
             content: Content.createReusableOverlayDecorationView(frame:bounds),
             frame: bounds
         )
@@ -40,10 +40,10 @@ final class ItemCell<Content:ItemContent> : UICollectionViewCell, AnyItemCell
         return view
     }()
     
-    private(set) var overlayDecorationIfLoaded : OverlayDecorationView? = nil
+    private(set) var overlayDecorationIfLoaded : DecorationView<Content.OverlayDecorationView>? = nil
     
-    private(set) lazy var underlayDecoration : UnderlayDecorationView = {
-        let view = UnderlayDecorationView(
+    private(set) lazy var underlayDecoration : DecorationView<Content.UnderlayDecorationView> = {
+        let view = DecorationView<Content.UnderlayDecorationView>(
             content: Content.createReusableUnderlayDecorationView(frame:bounds),
             frame: bounds
         )
@@ -55,7 +55,7 @@ final class ItemCell<Content:ItemContent> : UICollectionViewCell, AnyItemCell
         return view
     }()
     
-    private(set) var underlayDecorationIfLoaded : UnderlayDecorationView? = nil
+    private(set) var underlayDecorationIfLoaded : DecorationView<Content.UnderlayDecorationView>? = nil
     
     let contentContainer : ContentContainerView
 
@@ -231,50 +231,11 @@ final class ItemCell<Content:ItemContent> : UICollectionViewCell, AnyItemCell
 
 extension ItemCell {
     
-    final class OverlayDecorationView : UIView {
+    final class DecorationView<ContentView:UIView> : UIView {
         
-        let content : Content.OverlayDecorationView
+        let content : ContentView
         
-        init(content : Content.OverlayDecorationView, frame: CGRect) {
-            
-            self.content = content
-            
-            super.init(frame: frame)
-            
-            self.content.frame = bounds
-            self.addSubview(self.content)
-            
-            self.isUserInteractionEnabled = false
-        }
-        
-        @available(*, unavailable)
-        required init?(coder: NSCoder) { fatalError() }
-        
-        override func layoutSubviews() {
-            super.layoutSubviews()
-            
-            self.content.frame = self.bounds
-        }
-        
-        override var isAccessibilityElement: Bool {
-            get { false }
-            set { fatalError("Cannot set isAccessibilityElement.") }
-        }
-        
-        override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-            false
-        }
-        
-        override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-            nil
-        }
-    }
-    
-    final class UnderlayDecorationView : UIView {
-        
-        let content : Content.UnderlayDecorationView
-        
-        init(content : Content.UnderlayDecorationView, frame: CGRect) {
+        init(content : ContentView, frame: CGRect) {
             
             self.content = content
             

--- a/ListableUI/Sources/Item/ItemContent.swift
+++ b/ListableUI/Sources/Item/ItemContent.swift
@@ -432,7 +432,10 @@ public protocol ItemContent : AnyItemConvertible where Coordinator.ItemContentTy
     /// The content view is drawn at the top of the view hierarchy, above the background views.
     associatedtype OverlayDecorationView:UIView = UIView
     
-
+    /// The content view used to draw the content.
+    /// The content view is drawn at the bottom of the view hierarchy, above the background views.
+    associatedtype UnderlayDecorationView:UIView = UIView
+    
     /// Create and return a new overlay decoration view used to render any required decorations over the content.
     /// The decoration view appears above all content, and is not affected by swipe actions.
     ///
@@ -447,7 +450,7 @@ public protocol ItemContent : AnyItemConvertible where Coordinator.ItemContentTy
     /// ## Note
     /// Do not do configuration in this method that will be changed by your view's theme or appearance – instead
     /// do that work in `apply(to:)`, so the appearance will be updated if the appearance of content changes.
-    static func createReusableUnderlayDecorationView(frame : CGRect) -> OverlayDecorationView
+    static func createReusableUnderlayDecorationView(frame : CGRect) -> UnderlayDecorationView
     
     //
     // MARK: Content Coordination
@@ -522,14 +525,14 @@ public struct ItemContentViews<Content:ItemContent>
 
     /// The underlay decoration view of the content.
     /// Always displayed under the content, and does not react to swipe actions.
-    public var underlayDecoration : Content.OverlayDecorationView {
+    public var underlayDecoration : Content.UnderlayDecorationView {
         cell.underlayDecoration.content
     }
     
     /// The underlay decoration view of the content, if it has been loaded.
     /// Always displayed under the content, and does not react to swipe actions.
-    public var underlayDecorationIfLoaded : Content.OverlayDecorationView? {
-        cell.overlayDecorationIfLoaded?.content
+    public var underlayDecorationIfLoaded : Content.UnderlayDecorationView? {
+        cell.underlayDecorationIfLoaded?.content
     }
 }
 
@@ -698,10 +701,10 @@ public extension ItemContent where OverlayDecorationView == UIView
 
 
 /// Provide a UIView when no special underlay decoration view is specified.
-public extension ItemContent where OverlayDecorationView == UIView
+public extension ItemContent where UnderlayDecorationView == UIView
 {
-    static func createReusableUnderlayDecorationView(frame : CGRect) -> OverlayDecorationView
+    static func createReusableUnderlayDecorationView(frame : CGRect) -> UnderlayDecorationView
     {
-        OverlayDecorationView(frame: frame)
+        UnderlayDecorationView(frame: frame)
     }
 }

--- a/ListableUI/Sources/Item/ItemContent.swift
+++ b/ListableUI/Sources/Item/ItemContent.swift
@@ -444,7 +444,7 @@ public protocol ItemContent : AnyItemConvertible where Coordinator.ItemContentTy
     /// do that work in `apply(to:)`, so the appearance will be updated if the appearance of content changes.
     static func createReusableOverlayDecorationView(frame : CGRect) -> OverlayDecorationView
     
-    /// Create and return a new underrlay decoration view used to render any required decorations under the content.
+    /// Create and return a new underlay decoration view used to render any required decorations under the content.
     /// The decoration view appears under all content as a background, and is not affected by swipe actions.
     ///
     /// ## Note

--- a/ListableUI/Sources/Item/ItemContent.swift
+++ b/ListableUI/Sources/Item/ItemContent.swift
@@ -441,6 +441,14 @@ public protocol ItemContent : AnyItemConvertible where Coordinator.ItemContentTy
     /// do that work in `apply(to:)`, so the appearance will be updated if the appearance of content changes.
     static func createReusableOverlayDecorationView(frame : CGRect) -> OverlayDecorationView
     
+    /// Create and return a new underrlay decoration view used to render any required decorations under the content.
+    /// The decoration view appears under all content as a background, and is not affected by swipe actions.
+    ///
+    /// ## Note
+    /// Do not do configuration in this method that will be changed by your view's theme or appearance – instead
+    /// do that work in `apply(to:)`, so the appearance will be updated if the appearance of content changes.
+    static func createReusableUnderlayDecorationView(frame : CGRect) -> OverlayDecorationView
+    
     //
     // MARK: Content Coordination
     //
@@ -509,6 +517,18 @@ public struct ItemContentViews<Content:ItemContent>
     /// The overlay decoration view of the content, if it has been loaded.
     /// Always displayed over the content, and does not react to swipe actions.
     public var overlayDecorationIfLoaded : Content.OverlayDecorationView? {
+        cell.overlayDecorationIfLoaded?.content
+    }
+
+    /// The underlay decoration view of the content.
+    /// Always displayed under the content, and does not react to swipe actions.
+    public var underlayDecoration : Content.OverlayDecorationView {
+        cell.underlayDecoration.content
+    }
+    
+    /// The underlay decoration view of the content, if it has been loaded.
+    /// Always displayed under the content, and does not react to swipe actions.
+    public var underlayDecorationIfLoaded : Content.OverlayDecorationView? {
         cell.overlayDecorationIfLoaded?.content
     }
 }
@@ -671,6 +691,16 @@ public extension ItemContent where SelectedBackgroundView == UIView
 public extension ItemContent where OverlayDecorationView == UIView
 {
     static func createReusableOverlayDecorationView(frame : CGRect) -> OverlayDecorationView
+    {
+        OverlayDecorationView(frame: frame)
+    }
+}
+
+
+/// Provide a UIView when no special underlay decoration view is specified.
+public extension ItemContent where OverlayDecorationView == UIView
+{
+    static func createReusableUnderlayDecorationView(frame : CGRect) -> OverlayDecorationView
     {
         OverlayDecorationView(frame: frame)
     }


### PR DESCRIPTION
Added an optional underlay view to item cells. 

The problem mainly solved was to provide a view where we can set a background color when performing swipe actions with insets for cells that have a different color background than their list. In the before / after images, if you look at the swipe action, you'll notice that there is no longe a white "border" visible around the swipe action. The changes to the demo for the images are not a part of this PR, but clients will have to just implement something like:

```
        func underlayDecorationElement(with info: ApplyItemContentInfo) -> Element? {
            Empty().box(background: .cyan)
        }
```

|Before|After|
|:-:|:-:|
|![image1](https://github.com/square/Listable/assets/39274622/074b5b19-9177-4256-8f78-53bb4816d60a)|![image2](https://github.com/square/Listable/assets/39274622/84f6a4d9-9513-4fb8-9102-6d5ddd08378a)|

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.



