### PR TITLE
Allow programmatically showing leading and trailing swipe actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- You may now programatically reveal leading and trailing swipe actions, by calling the `showLeadingSwipeActions` or `showTrailingSwipeActions` closures on `ApplyItemContentInfo`.
+
 ### Removed
 
 ### Changed

--- a/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
@@ -284,6 +284,17 @@ final class SwipeActionsViewController: UIViewController  {
         func element(with info : ApplyItemContentInfo) -> Element {
             Column(alignment: .fill) {
                 Row(alignment: .center, underflow: .spaceEvenly, minimumSpacing: 8) {
+                    
+                    Label(text: "T")
+                        .tappable {
+                            info.showTrailingSwipeActions()
+                        }
+                    
+                    Label(text: "L")
+                        .tappable {
+                            info.showLeadingSwipeActions()
+                        }
+                    
                     Column {
                         Label(text: item.title)
                         

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -262,6 +262,10 @@ extension ItemCell {
             }
         }
 
+        func openSwipeActionsAnimated(on side : SwipeActionState.Side) {
+            self.set(state: .open(side), animated: true)
+        }
+        
         func performAnimatedClose() {
             self.set(state: .closed, animated: true)
         }

--- a/ListableUI/Sources/Internal/ItemCell.swift
+++ b/ListableUI/Sources/Internal/ItemCell.swift
@@ -10,6 +10,9 @@ import UIKit
 
 protocol AnyItemCell : UICollectionViewCell
 {
+    func openLeadingSwipeActions()
+    func openTrailingSwipeActions()
+    
     func closeSwipeActions()
     
     var areSwipeActionsVisible : Bool  { get }
@@ -180,6 +183,14 @@ final class ItemCell<Content:ItemContent> : UICollectionViewCell, AnyItemCell
     }
     
     // MARK: AnyItemCell
+    
+    func openLeadingSwipeActions() {
+        self.contentContainer.openSwipeActionsAnimated(on: .left)
+    }
+    
+    func openTrailingSwipeActions() {
+        self.contentContainer.openSwipeActionsAnimated(on: .right)
+    }
     
     func closeSwipeActions() {
         self.contentContainer.performAnimatedClose()

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
@@ -281,6 +281,12 @@ extension PresentationState
                 state: itemState,
                 position: self.itemPosition,
                 reorderingActions: self.reorderingActions,
+                showLeadingSwipeActions: { [weak cell] in
+                    cell?.openLeadingSwipeActions()
+                },
+                showTrailingSwipeActions: { [weak cell] in
+                    cell?.openTrailingSwipeActions()
+                },
                 isReorderable: self.model.reordering != nil,
                 environment: environment
             )

--- a/ListableUI/Sources/Item/ItemContent.swift
+++ b/ListableUI/Sources/Item/ItemContent.swift
@@ -556,6 +556,12 @@ public struct ApplyItemContentInfo
     /// Provides access to actions to handle re-ordering the content within the list.
     public var reorderingActions : ReorderingActions
     
+    /// When invoked, will show the leading swipe actions.
+    public var showLeadingSwipeActions : () -> ()
+    
+    /// When invoked, will show the trailing swipe actions.
+    public var showTrailingSwipeActions : () -> ()
+    
     /// If the item can be reordered.
     /// Use this property to determine if your `ItemContent` should display a reorder control.
     public var isReorderable : Bool


### PR DESCRIPTION
This will be part of supporting the iOS-style delete actions on `MarketRow`:

![image](https://github.com/square/Listable/assets/327847/8d93922e-9eac-44e9-8f37-e6c65ab311ec)

https://github.com/square/Listable/assets/327847/fecd53d1-9864-4693-ab62-f5eacacf87d0

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
