### PR TITLE
Update CI script to reference the `xcodesorg/made/xcodes` package for installing simulator runtimes.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -80,7 +80,7 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_14.2.app
 
       - name: Install xcodes
-        run: brew install robotsandpencils/made/xcodes
+        run: brew install aria2 xcodesorg/made/xcodes
 
       - name: Install iOS ${{ matrix.sdk }}
         run: sudo xcodes runtimes install "iOS 15.2"
@@ -129,7 +129,7 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_14.2.app
 
       - name: Install xcodes
-        run: brew install robotsandpencils/made/xcodes
+        run: brew install aria2 xcodesorg/made/xcodes
 
       - name: Install iOS ${{ matrix.sdk }}
         run: sudo xcodes runtimes install "iOS 14.5"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 ### Internal
 
+- Update CI script to reference the `xcodesorg/made/xcodes` package for installing simulator runtimes.
+- Update CI script to install `aria2` to improve simulator runtime download speeds.
+
 # Past Releases
 
 # [11.0.0] - 2023-06-15


### PR DESCRIPTION
- Update CI script to reference the `xcodesorg/made/xcodes` package for installing simulator runtimes.
- Update CI script to install `aria2` to improve simulator runtime download speeds.
  - This matches [what is used in Blueprint](https://github.com/square/Blueprint/blob/f9bad5fa65f983f0b8837558b490bb53718d6349/.github/workflows/tests.yaml#L38).

Fixes CI failures [like this one](https://github.com/square/Listable/actions/runs/5508887091/jobs/10040796817).

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
