### PR TITLE
CONV-1435: Content gravity for chat apps

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0A0E070423870A5700DDD27D /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 0A0E070323870A5700DDD27D /* README.md */; };
 		0A1306E7272F29B300F6DDDD /* BestPractices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1306E6272F29B300F6DDDD /* BestPractices.swift */; };
 		0A49210424E5E11300D17038 /* AccordionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A49210324E5E11300D17038 /* AccordionViewController.swift */; };
+		0A4D74B92A284B8900B5CD32 /* ChatDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4D74B82A284B8900B5CD32 /* ChatDemoViewController.swift */; };
 		0A57BA2D274FFCE000A118BD /* FlowLayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A57BA2C274FFCE000A118BD /* FlowLayoutViewController.swift */; };
 		0A5DC1A924F6FD4200DC7C14 /* ListAppearsAfterKeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5DC1A824F6FD4200DC7C14 /* ListAppearsAfterKeyboardViewController.swift */; };
 		0A5F5CCF257EC2D7003CCE2C /* LocalizedCollationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5F5CCE257EC2D7003CCE2C /* LocalizedCollationViewController.swift */; };
@@ -62,6 +63,7 @@
 		0A1306E6272F29B300F6DDDD /* BestPractices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestPractices.swift; sourceTree = "<group>"; };
 		0A1306EA272F762500F6DDDD /* TASKLIST.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = TASKLIST.md; path = ../TASKLIST.md; sourceTree = "<group>"; };
 		0A49210324E5E11300D17038 /* AccordionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccordionViewController.swift; sourceTree = "<group>"; };
+		0A4D74B82A284B8900B5CD32 /* ChatDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDemoViewController.swift; sourceTree = "<group>"; };
 		0A57BA2C274FFCE000A118BD /* FlowLayoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayoutViewController.swift; sourceTree = "<group>"; };
 		0A5DC1A824F6FD4200DC7C14 /* ListAppearsAfterKeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAppearsAfterKeyboardViewController.swift; sourceTree = "<group>"; };
 		0A5F5CCE257EC2D7003CCE2C /* LocalizedCollationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedCollationViewController.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 				8ECEBF6128B7E4C200ECEC56 /* CenterSnappingTableViewController.swift */,
 				0AA4D9B2248064A300CF95A5 /* CollectionViewAppearance.swift */,
 				0AA4D9B8248064A300CF95A5 /* CollectionViewBasicDemoViewController.swift */,
+				0A4D74B82A284B8900B5CD32 /* ChatDemoViewController.swift */,
 				0AA4D9B6248064A300CF95A5 /* SearchableDictionaryViewController.swift */,
 				0A57BA2C274FFCE000A118BD /* FlowLayoutViewController.swift */,
 				0AA4D9B0248064A300CF95A5 /* CoordinatorViewController.swift */,
@@ -471,6 +474,7 @@
 				0AA4D9C0248064A300CF95A5 /* InvoicesPaymentScheduleDemoViewController.swift in Sources */,
 				0A66420B254A317A007F6B2F /* AutoLayoutDemoViewController.swift in Sources */,
 				0AEB96E222FBCC1D00341DFF /* AppDelegate.swift in Sources */,
+				0A4D74B92A284B8900B5CD32 /* ChatDemoViewController.swift in Sources */,
 				0A793B5824E4B53500850139 /* ManualSelectionManagementViewController.swift in Sources */,
 				8ECEBF6228B7E4C200ECEC56 /* CenterSnappingTableViewController.swift in Sources */,
 				0AC839A525EEAD110055CEF5 /* OnTapItemAnimationViewController.swift in Sources */,
@@ -673,7 +677,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2HQ24J954F;
+				DEVELOPMENT_TEAM = 5SS5JN4A9Q;
 				INFOPLIST_FILE = Demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -692,7 +696,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2HQ24J954F;
+				DEVELOPMENT_TEAM = 5SS5JN4A9Q;
 				INFOPLIST_FILE = Demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Demo/Sources/Demos/Demo Screens/ChatDemoViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ChatDemoViewController.swift
@@ -70,7 +70,13 @@ final class ChatDemoViewController : UIViewController {
         messages.insert((UUID(), .random), at: 0)
         messages.insert((UUID(), .random), at: 0)
         messages.insert((UUID(), .random), at: 0)
-        self.reload()
+        if listView.isContentScrollable {
+            UIView.performWithoutAnimation {
+                self.reload()
+            }
+        } else {
+            self.reload()
+        }
     }
     
     @objc private func addAtBottom() {

--- a/Demo/Sources/Demos/Demo Screens/ChatDemoViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ChatDemoViewController.swift
@@ -1,0 +1,214 @@
+//
+//  ChatDemoViewController.swift
+//  Demo
+//
+//  Created by Kyle Van Essen on 5/31/23.
+//  Copyright © 2023 Kyle Van Essen. All rights reserved.
+//
+
+import ListableUI
+import BlueprintUI
+import BlueprintUICommonControls
+import BlueprintUILists
+
+
+final class ChatDemoViewController : UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(title: "Top", style: .plain, target: self, action: #selector(addAtTop)),
+            UIBarButtonItem(title: "Bottom", style: .plain, target: self, action: #selector(addAtBottom)),
+        ]
+
+        self.view.addSubview(listView)
+        listView.translatesAutoresizingMaskIntoConstraints = true
+        listView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        listView.frame = view.bounds
+
+        listView.customScrollViewInsets = { [weak self] in
+            guard let self = self else { return .zero }
+            let inset = max(self.footerHeight, self.keyboardHeight)
+            print("inset", inset)
+            return UIEdgeInsets(
+               top: 0,
+               left: 0,
+               bottom: inset,
+               right: 0
+           )
+        }
+        listView.updateScrollViewInsets()
+        listView.onKeyboardFrameWillChange = { [weak self] keyboardCurrentFrameProvider, keyboardAnimation in
+            guard let self = self else { return }
+            switch keyboardCurrentFrameProvider.currentFrame(in: self.view) {
+            case .overlapping(frame: let frame):
+                self.keyboardHeight = frame.height
+            case .nonOverlapping, .none:
+                self.keyboardHeight = 0
+            }
+            
+            UIView.animate(
+                withDuration: keyboardAnimation.animationDuration,
+                delay: 0.0,
+                options: keyboardAnimation.options,
+                animations: {
+                    self.listView.updateScrollViewInsets()
+                }
+            )
+        }
+        
+        self.view.addSubview(footerView)
+        footerView.translatesAutoresizingMaskIntoConstraints = false
+
+        self.reload()
+    }
+    
+    @objc private func addAtTop() {
+        messages.insert((UUID(), .random), at: 0)
+        messages.insert((UUID(), .random), at: 0)
+        messages.insert((UUID(), .random), at: 0)
+        messages.insert((UUID(), .random), at: 0)
+        messages.insert((UUID(), .random), at: 0)
+        self.reload()
+    }
+    
+    @objc private func addAtBottom() {
+        messages.append((UUID(), .random))
+        self.reload()
+    }
+
+    private var footerHeight: CGFloat = 50
+    private var keyboardHeight: CGFloat = 0
+    private let listView = ListView()
+    private var footerView = BlueprintView()
+
+    private func reload()
+    {
+        configureListView()
+        footerView.element = Row(alignment: .center, minimumSpacing: 8) {
+            TextField(text: "").box(background: UIColor.white).inset(uniform: 8)
+            Button(
+                onTap: { [weak self] in
+                    guard let self = self else { return }
+                    guard self.footerHeight > 50 else { return }
+                    self.footerHeight -= 50
+                    self.footerView.frame.size.height = self.footerHeight
+                    self.reload()
+                    self.listView.updateScrollViewInsets()
+                },
+                wrapping: Label(text: "Decrease height")
+            )
+            Button(
+                onTap: { [weak self] in
+                    guard let self = self else { return }
+                    self.footerHeight += 50
+                    self.footerView.frame.size.height = self.footerHeight
+                    self.reload()
+                    self.listView.updateScrollViewInsets()
+                },
+                wrapping: Label(text: "Increase height")
+            )
+        }.box(background: UIColor.lightGray)
+    }
+
+    private func footerViewFrame() -> CGRect {
+        var frame = CGRect()
+        frame.size.width = view.bounds.width
+        frame.size.height = footerHeight
+        frame.origin.y = view.bounds.height - footerHeight
+        return frame
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        footerView.frame = footerViewFrame()
+    }
+
+    private var messages: [(UUID, MessageContent.Sender)] = [
+        (UUID(), .random),
+        (UUID(), .random),
+        (UUID(), .random),
+    ]
+    
+    private func configureListView() {
+        
+        listView.configure { list in
+            
+            list.layout = .table { layout in
+                layout.bounds = .init(
+                    padding: .init(top: 20, left: 20, bottom: 20, right: 20),
+                    width: .atMost(600)
+                )
+                
+                layout.layout.itemSpacing = 10
+            }
+            
+            list.behavior.verticalLayoutGravity = .bottom
+            list.behavior.keyboardAdjustmentMode = .custom
+            
+            list.refreshControl = .init(isRefreshing: false) {
+                print("Refreshy")
+            }
+            
+            list.add {
+                Section("messages") {
+                    for (id, sender) in messages {
+                        MessageContent(
+                            identifierValue: id,
+                            sender: sender,
+                            content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nec nibh dui."
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+fileprivate struct MessageContent : BlueprintItemContent, Equatable {
+    
+    var identifierValue: AnyHashable
+    
+    var sender : Sender
+    
+    var content : String
+    
+    enum Sender : Equatable {
+        case me
+        case other
+        
+        static var random : Self {
+            if Bool.random() {
+                return .me
+            } else {
+                return .other
+            }
+        }
+    }
+    
+    func element(with info: ApplyItemContentInfo) -> Element {
+        Label(text: content) {
+            $0.font = .systemFont(ofSize: 16, weight: .medium)
+            $0.color = .white
+        }
+        .inset(uniform: 12)
+        .box(background: backgroundColor, corners: .rounded(radius: 10))
+        .constrainedTo(width: .atMost(300))
+        .aligned(horizontally: horizontalAlignment)
+    }
+    
+    private var backgroundColor : UIColor {
+        switch sender {
+        case .me: return .systemBlue
+        case .other: return .systemGray2
+        }
+    }
+    
+    private var horizontalAlignment : Aligned.HorizontalAlignment {
+        switch sender {
+        case .me: return .trailing
+        case .other: return .leading
+        }
+    }
+}

--- a/Demo/Sources/Demos/Demo Screens/KeyboardTestingViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/KeyboardTestingViewController.swift
@@ -53,6 +53,8 @@ final class KeyboardTestingViewController : UIViewController
             self.listView.behavior.keyboardAdjustmentMode = .adjustsWhenVisible
         case .adjustsWhenVisible:
             self.listView.behavior.keyboardAdjustmentMode = .none
+        case .custom:
+            self.listView.behavior.keyboardAdjustmentMode = .custom
         }
     }
 }

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -82,6 +82,14 @@ public final class DemosRootViewController : ListViewController
                 )
                 
                 Item(
+                    DemoItem(text: "Chat App"),
+                    selectionStyle: .selectable(),
+                    onSelect : { _ in
+                        self?.push(ChatDemoViewController())
+                    }
+                )
+                
+                Item(
                     DemoItem(text: "English Dictionary Search"),
                     selectionStyle: .selectable(),
                     onSelect : { _ in

--- a/ListableUI/Sources/Behavior.swift
+++ b/ListableUI/Sources/Behavior.swift
@@ -41,6 +41,8 @@ public struct Behavior : Equatable
 
     /// The rate at which scrolling decelerates.
     public var decelerationRate: DecelerationRate
+    
+    public var verticalLayoutGravity : VerticalLayoutGravity
 
     /// Creates a new `Behavior` based on the provided parameters.
     public init(
@@ -52,7 +54,8 @@ public struct Behavior : Equatable
         canCancelContentTouches : Bool = true,
         delaysContentTouches : Bool = true,
         isPagingEnabled : Bool = false,
-        decelerationRate : DecelerationRate = .normal
+        decelerationRate : DecelerationRate = .normal,
+        verticalLayoutGravity : VerticalLayoutGravity = .top
     ) {
         self.keyboardDismissMode = keyboardDismissMode
         self.keyboardAdjustmentMode = keyboardAdjustmentMode
@@ -66,6 +69,8 @@ public struct Behavior : Equatable
         self.delaysContentTouches = delaysContentTouches
         self.isPagingEnabled = false
         self.decelerationRate = decelerationRate
+        
+        self.verticalLayoutGravity = verticalLayoutGravity
     }
 }
 
@@ -80,6 +85,11 @@ extension Behavior
         
         /// The `contentInset` of the list is adjusted when the keyboard appears or disappears.
         case adjustsWhenVisible
+
+        /// Consumer calculates the edge insets and handles setting them
+        /// via the `ListView#customScrollViewInsets` callback. Only use this option
+        /// when managing the `ListView` directly.
+        case custom
     }
     
     
@@ -165,6 +175,12 @@ extension Behavior
                 }
             }
         }
+    }
+    
+    // TODO: Remove 'vertical', rename to start/end
+    public enum VerticalLayoutGravity {
+        case top
+        case bottom
     }
 }
 

--- a/ListableUI/Sources/KeyboardObserver/KeyboardObserver.swift
+++ b/ListableUI/Sources/KeyboardObserver/KeyboardObserver.swift
@@ -7,6 +7,20 @@
 
 import UIKit
 
+public protocol KeyboardCurrentFrameProviding {
+    func currentFrame(in view : UIView) -> KeyboardFrame?
+}
+
+public enum KeyboardFrame : Equatable {
+
+    /// The current frame does not overlap the current view at all.
+    case nonOverlapping
+
+    /// The current frame does overlap the view, by the provided rect, in the view's coordinate space.
+    case overlapping(frame: CGRect)
+}
+
+extension KeyboardObserver: KeyboardCurrentFrameProviding {}
 
 @_spi(ListableKeyboard)
 public protocol KeyboardObserverDelegate : AnyObject {
@@ -122,15 +136,6 @@ public final class KeyboardObserver {
     //
     // MARK: Handling Changes
     //
-
-    public enum KeyboardFrame : Equatable {
-
-        /// The current frame does not overlap the current view at all.
-        case nonOverlapping
-
-        /// The current frame does overlap the view, by the provided rect, in the view's coordinate space.
-        case overlapping(frame: CGRect)
-    }
 
     /// How the keyboard overlaps the view provided. If the view is not on screen (eg, no window),
     /// or the observer has not yet learned about the keyboard's position, this method returns nil.

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -250,6 +250,7 @@ public final class ListView : UIView
         self.collectionViewLayout.behavior = self.behavior
         
         self.collectionView.verticalLayoutGravity = self.behavior.verticalLayoutGravity
+        self.collectionView.layoutDirection = self.collectionViewLayout.layout.direction
         
         self.collectionView.keyboardDismissMode = self.behavior.keyboardDismissMode
         
@@ -315,6 +316,11 @@ public final class ListView : UIView
         KeyboardCurrentFrameProviding,
         (animationDuration: Double, options: UIView.AnimationOptions)
     ) -> Void
+
+    /// Returns true when the content size is large enough that scrolling is possible
+    public var isContentScrollable: Bool {
+        collectionView.isContentScrollable
+    }
 
     /// Called whenever a keyboard change is detected
     public var onKeyboardFrameWillChange: KeyboardFrameWillChangeCallback? = nil
@@ -1613,6 +1619,7 @@ fileprivate extension UIScrollView
 final class CollectionView : ListView.IOS16_4_First_Responder_Bug_CollectionView {
     
     var verticalLayoutGravity : Behavior.VerticalLayoutGravity = .top
+    var layoutDirection: LayoutDirection = .vertical
 
     override var contentSize: CGSize {
 
@@ -1665,9 +1672,17 @@ final class CollectionView : ListView.IOS16_4_First_Responder_Bug_CollectionView
     }
 
     /// Returns true when the content size is large enough that scrolling is possible
-    private var isContentScrollable: Bool {
-        return contentSize.height > bounds.height - contentInset.bottom - contentInset.top + (
-            contentOffset.y < 0 ? contentOffset.y : 0
-        )
+    var isContentScrollable: Bool {
+        switch layoutDirection {
+        case .vertical:
+            return contentSize.height > bounds.height - contentInset.bottom - contentInset.top + (
+                contentOffset.y < 0 ? contentOffset.y : 0
+            )
+        case .horizontal:
+            return contentSize.width > bounds.width - contentInset.left - contentInset.right + (
+                contentOffset.x < 0 ? contentOffset.x : 0
+            )
+
+        }
     }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,16 +2,16 @@ PODS:
   - BlueprintUI (2.0.0)
   - BlueprintUICommonControls (2.0.0):
     - BlueprintUI (= 2.0.0)
-  - BlueprintUILists (10.2.0):
+  - BlueprintUILists (10.3.0):
     - BlueprintUI (~> 2.0)
     - ListableUI
-  - BlueprintUILists/Tests (10.2.0):
+  - BlueprintUILists/Tests (10.3.0):
     - BlueprintUI (~> 2.0)
     - BlueprintUICommonControls (~> 2.0)
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
-  - ListableUI (10.2.0)
-  - ListableUI/Tests (10.2.0):
+  - ListableUI (10.3.0)
+  - ListableUI/Tests (10.3.0):
     - EnglishDictionary
     - Snapshot
   - Snapshot (1.0.0.LOCAL)
@@ -46,9 +46,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BlueprintUI: a1adeb91f76c88dd499ad693251aa96919b1c2a4
   BlueprintUICommonControls: 9e02875bc6b8ef64aa9634c32d7156bd50c7b88d
-  BlueprintUILists: eea0272053526e6e2beabffa75b62429bc9a916a
+  BlueprintUILists: 7656fc2de45eacd1f2d2949fd3ac5e8de96daa8e
   EnglishDictionary: 277ff15917abc170362afbd2ad11cbe15c2ae6ad
-  ListableUI: b093b8d562013d0ffc32e8848a47ba34e8a487f6
+  ListableUI: b63a3b383da2110374125a5d763d7023d39d0f2d
   Snapshot: a936e73ede9570c80fb55e20542903e81efbad82
 
 PODFILE CHECKSUM: 2ca1d80570fc765312a79bcaa886ee9034caabd2


### PR DESCRIPTION
As suggested, breaking this PR up into smaller ones:

1st - https://github.com/square/Listable/pull/496
2nd - https://github.com/square/Listable/pull/497
3rd - https://github.com/square/Listable/pull/498

------

- Adds a behavior to enable gravity for a chat app
- Adds a `custom` `KeyboardAdjustmentMode` that gives the consumer complete control over the insets
- Adds `ListView#onKeyboardFrameWillChange` to listen to keyboard changes
- and `ListView#customScrollViewInsets` to customize the insets
- Makes `updateScrollViewInsets` public so that the consumer can trigger inset updates
- Adds a Chat app demo

**Demo for the 1st commit:**

https://github.com/square/Listable/assets/73715873/62cca352-7cbb-40fb-ba35-18e44389d712


**Demo for the 2nd  & 3rd commit which adds a workaround for the janky animation when items are added to the top, and realistic paging in the demo**

https://github.com/square/Listable/assets/73715873/73bcdd27-ecd6-4ab3-b2b7-ee76da3677a6


### Checklist

Please do the following before merging:

- [ ] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
