### PR TITLE
CONV-1435: Add ListView#isContentScrollable property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - `ApplyItemContentInfo` and `ApplyHeaderFooterContentInfo` are now available in the Blueprint `Environment` for each `BlueprintItemContent`.
 
+- A new `isContentScrollable` property is added to `ListView` to determine if the content size is large enough that the list can be scrolled to a new position without springing back to it's original position.
+
 ### Removed
 
 ### Changed

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -40,7 +40,7 @@ public final class ListView : UIView
             behavior: self.behavior
         )
 
-        self.collectionView = IOS16_4_First_Responder_Bug_CollectionView(
+        self.collectionView = CollectionView(
             frame: CGRect(origin: .zero, size: frame.size),
             collectionViewLayout: initialLayout
         )
@@ -131,7 +131,7 @@ public final class ListView : UIView
     //
     
     let storage : Storage
-    let collectionView : IOS16_4_First_Responder_Bug_CollectionView
+    let collectionView : CollectionView
     let delegate : Delegate
     let layoutManager : LayoutManager
     let liveCells : LiveCells
@@ -297,7 +297,13 @@ public final class ListView : UIView
     //
     // MARK: Scroll Insets
     //
-    
+
+    /// Returns true when the content size is large enough that scrolling is possible
+    public var isContentScrollable: Bool {
+        collectionView.isContentScrollable
+    }
+
+
     public var scrollIndicatorInsets : UIEdgeInsets {
         didSet {
             guard oldValue != self.scrollIndicatorInsets else {
@@ -1573,5 +1579,26 @@ fileprivate extension UIScrollView
         
         // We are within one half view height from the bottom of the content.
         return self.contentOffset.y + (viewHeight * 1.5) > self.contentSize.height
+    }
+}
+
+
+final class CollectionView : ListView.IOS16_4_First_Responder_Bug_CollectionView {
+    
+    var layoutDirection: LayoutDirection = .vertical
+
+    /// Returns true when the content size is large enough that scrolling is possible
+    var isContentScrollable: Bool {
+        switch layoutDirection {
+        case .vertical:
+            return contentSize.height > bounds.height - adjustedContentInset.bottom - adjustedContentInset.top + (
+                contentOffset.y < 0 ? contentOffset.y : 0
+            )
+        case .horizontal:
+            return contentSize.width > bounds.width - adjustedContentInset.left - adjustedContentInset.right + (
+                contentOffset.x < 0 ? contentOffset.x : 0
+            )
+
+        }
     }
 }

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1588,16 +1588,13 @@ final class CollectionView : ListView.IOS16_4_First_Responder_Bug_CollectionView
     var layoutDirection: LayoutDirection = .vertical
 
     /// Returns true when the content size is large enough that scrolling is possible
+    /// without bouncing back to it's original position.
     var isContentScrollable: Bool {
         switch layoutDirection {
         case .vertical:
-            return contentSize.height > bounds.height - adjustedContentInset.bottom - adjustedContentInset.top + (
-                contentOffset.y < 0 ? contentOffset.y : 0
-            )
+            return contentSize.height > visibleContentFrame.height
         case .horizontal:
-            return contentSize.width > bounds.width - adjustedContentInset.left - adjustedContentInset.right + (
-                contentOffset.x < 0 ? contentOffset.x : 0
-            )
+            return contentSize.width > visibleContentFrame.width
 
         }
     }


### PR DESCRIPTION
- Add this property to ListView. It will be used in conjunction with upcoming so-called gravity scrolling changes to workaround an animation issue with paging

broken out of this PR: https://github.com/square/Listable/pull/495

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
