### PR TITLE
CONV-1435: Add scroll indicator insets to customScrollViewInsets

### DIFF
--- a/Demo/Sources/Demos/Demo Screens/ChatDemoViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ChatDemoViewController.swift
@@ -27,7 +27,7 @@ final class ChatDemoViewController : UIViewController {
         listView.frame = view.bounds
 
         listView.customScrollViewInsets = { [weak self] in
-            guard let self = self else { return (.zero, .zero, .zero) }
+            guard let self = self else { return .init() }
             let inset = max(self.footerHeight, self.keyboardHeight - self.view.safeAreaInsets.bottom)
             print("new bottom inset:", inset)
             let insets = UIEdgeInsets(
@@ -36,7 +36,7 @@ final class ChatDemoViewController : UIViewController {
                 bottom: inset,
                 right: 0
             )
-            return (insets, .zero, insets)
+            return .init(content: insets, verticalScroll: insets)
         }
         listView.onKeyboardFrameWillChange = { [weak self] keyboardCurrentFrameProvider, keyboardAnimation in
             guard let self = self else { return }

--- a/Demo/Sources/Demos/Demo Screens/ChatDemoViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ChatDemoViewController.swift
@@ -27,15 +27,16 @@ final class ChatDemoViewController : UIViewController {
         listView.frame = view.bounds
 
         listView.customScrollViewInsets = { [weak self] in
-            guard let self = self else { return .zero }
+            guard let self = self else { return (.zero, .zero, .zero) }
             let inset = max(self.footerHeight, self.keyboardHeight - self.view.safeAreaInsets.bottom)
             print("new bottom inset:", inset)
-            return UIEdgeInsets(
-               top: 0,
-               left: 0,
-               bottom: inset,
-               right: 0
-           )
+            let insets = UIEdgeInsets(
+                top: 0,
+                left: 0,
+                bottom: inset,
+                right: 0
+            )
+            return (insets, .zero, insets)
         }
         listView.onKeyboardFrameWillChange = { [weak self] keyboardCurrentFrameProvider, keyboardAnimation in
             guard let self = self else { return }

--- a/Demo/Sources/Demos/Demo Screens/KeyboardTestingViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/KeyboardTestingViewController.swift
@@ -27,7 +27,11 @@ final class KeyboardTestingViewController : UIViewController
         }
 
         self.listView.customScrollViewInsets = { [weak self] in
-            self?.insets ?? .zero
+            if let insets = self?.insets {
+                return (insets, insets, insets)
+            } else {
+                return (.zero, .zero, .zero)
+            }
         }
 
         self.listView.onKeyboardFrameWillChange = { [weak self] keyboardCurrentFrameProvider, animation in

--- a/Demo/Sources/Demos/Demo Screens/KeyboardTestingViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/KeyboardTestingViewController.swift
@@ -28,9 +28,9 @@ final class KeyboardTestingViewController : UIViewController
 
         self.listView.customScrollViewInsets = { [weak self] in
             if let insets = self?.insets {
-                return (insets, insets, insets)
+                return .init(content: insets, verticalScroll: insets)
             } else {
-                return (.zero, .zero, .zero)
+                return .init()
             }
         }
 

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -341,18 +341,15 @@ public final class ListView : UIView
     /// whenever insets require an update.
     public func updateScrollViewInsets()
     {
+        let insets: (content: UIEdgeInsets, horizontalScroll: UIEdgeInsets, verticalScroll: UIEdgeInsets)
         if case .custom = self.behavior.keyboardAdjustmentMode {
-            let insets = self.customScrollViewInsets()
-            self.collectionView.contentInset = insets.content
-            self.collectionView.horizontalScrollIndicatorInsets = insets.horizontalScroll
-            self.collectionView.verticalScrollIndicatorInsets = insets.verticalScroll
-            return
+            insets = self.customScrollViewInsets()
+        } else {
+            insets = self.calculateScrollViewInsets(
+                with: self.keyboardObserver.currentFrame(in: self)
+            )
         }
 
-        let insets = self.calculateScrollViewInsets(
-            with: self.keyboardObserver.currentFrame(in: self)
-        )
-        
         if self.collectionView.contentInset != insets.content {
             self.collectionView.contentInset = insets.content
         }

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -327,13 +327,35 @@ public final class ListView : UIView
     /// Called whenever a keyboard change is detected
     public var onKeyboardFrameWillChange: KeyboardFrameWillChangeCallback?
 
+    public struct ScrollViewInsets {
+        /// Insets for the content view
+        public let content: UIEdgeInsets
+
+        /// Insets for the horizontal scroll bar
+        public let horizontalScroll: UIEdgeInsets
+
+        /// Insets for the vertical scroll bar
+        public let verticalScroll: UIEdgeInsets
+        
+        /// All values are optional, and default to `.zero`
+        /// - Parameters:
+        ///   - content: Insets for the content view
+        ///   - horizontalScroll: Insets for the horizontal scroll bar
+        ///   - verticalScroll: Insets for the vertical scroll bar
+        public init(
+            content: UIEdgeInsets = .zero,
+            horizontalScroll: UIEdgeInsets = .zero,
+            verticalScroll: UIEdgeInsets = .zero
+        ) {
+            self.content = content
+            self.horizontalScroll = horizontalScroll
+            self.verticalScroll = verticalScroll
+        }
+    }
+
     /// This callback determines the scroll view's insets only when
     /// `behavior.keyboardAdjustmentMode` is `.custom`
-    public var customScrollViewInsets: () -> (
-        content: UIEdgeInsets,
-        horizontalScroll: UIEdgeInsets,
-        verticalScroll: UIEdgeInsets
-    ) = { (.zero, .zero, .zero) }
+    public var customScrollViewInsets: () -> ScrollViewInsets = { .init() }
 
     /// Call this to trigger an insets update.
     /// When the `keyboardAdjustmentMode` is `.custom`, you should set
@@ -341,7 +363,7 @@ public final class ListView : UIView
     /// whenever insets require an update.
     public func updateScrollViewInsets()
     {
-        let insets: (content: UIEdgeInsets, horizontalScroll: UIEdgeInsets, verticalScroll: UIEdgeInsets)
+        let insets: ScrollViewInsets
         if case .custom = self.behavior.keyboardAdjustmentMode {
             insets = self.customScrollViewInsets()
         } else {
@@ -363,8 +385,7 @@ public final class ListView : UIView
         }
     }
 
-    func calculateScrollViewInsets(with keyboardFrame : KeyboardFrame?) -> (content: UIEdgeInsets, horizontalScroll: UIEdgeInsets, verticalScroll: UIEdgeInsets)
-    {
+    func calculateScrollViewInsets(with keyboardFrame : KeyboardFrame?) -> ScrollViewInsets    {
         let keyboardBottomInset : CGFloat = {
             
             guard let keyboardFrame = keyboardFrame else {
@@ -401,7 +422,7 @@ public final class ListView : UIView
             $0.bottom = keyboardBottomInset
         }
         
-        return (
+        return .init(
             content: contentInsets,
             horizontalScroll: UIEdgeInsets(
                 top: 0,

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -329,7 +329,11 @@ public final class ListView : UIView
 
     /// This callback determines the scroll view's insets only when
     /// `behavior.keyboardAdjustmentMode` is `.custom`
-    public var customScrollViewInsets: () -> UIEdgeInsets = { .zero }
+    public var customScrollViewInsets: () -> (
+        content: UIEdgeInsets,
+        horizontalScroll: UIEdgeInsets,
+        verticalScroll: UIEdgeInsets
+    ) = { (.zero, .zero, .zero) }
 
     /// Call this to trigger an insets update.
     /// When the `keyboardAdjustmentMode` is `.custom`, you should set
@@ -338,7 +342,10 @@ public final class ListView : UIView
     public func updateScrollViewInsets()
     {
         if case .custom = self.behavior.keyboardAdjustmentMode {
-            self.collectionView.contentInset = self.customScrollViewInsets()
+            let insets = self.customScrollViewInsets()
+            self.collectionView.contentInset = insets.content
+            self.collectionView.horizontalScrollIndicatorInsets = insets.horizontalScroll
+            self.collectionView.verticalScrollIndicatorInsets = insets.verticalScroll
             return
         }
 


### PR DESCRIPTION
- Before: customScrollViewInsets only returns insets to adjust contentInset
- After: customScrollViewInsets function signature matches calculateScrollViewInsets so you can specify scroll-indicator insets
- Why? In the chat demo, the scroll bar was disappearing below the bottom inset of the list. It's likely that if you are modifying contentInset you will have to modify scroll indicator insets as well

### Before

https://github.com/square/Listable/assets/73715873/ef74979d-83fb-478d-a3df-0a33da9f6148

### After


https://github.com/square/Listable/assets/73715873/f4e048b1-6904-4ffb-a5b1-e836e18caf5d




### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
