### PR TITLE
CONV-1435: Gravity layout frame change fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- The `verticalLayoutGravity` behavior now takes into account `frame` changes so that the scroll position relative to the bottom remains unchanged when the `frame` changes.
+
 ### Added
 
 ### Removed

--- a/Demo/Sources/Demos/Demo Screens/ChatDemoViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ChatDemoViewController.swift
@@ -19,6 +19,8 @@ final class ChatDemoViewController : UIViewController {
         
         self.navigationItem.rightBarButtonItems = [
             UIBarButtonItem(title: "New message", style: .plain, target: self, action: #selector(addAtBottom)),
+            UIBarButtonItem(title: "Grow Frame", style: .plain, target: self, action: #selector(growFrame)),
+            UIBarButtonItem(title: "Shrink Frame", style: .plain, target: self, action: #selector(shrinkFrame)),
         ]
 
         self.view.addSubview(listView)
@@ -29,7 +31,6 @@ final class ChatDemoViewController : UIViewController {
         listView.customScrollViewInsets = { [weak self] in
             guard let self = self else { return .init() }
             let inset = max(self.footerHeight, self.keyboardHeight - self.view.safeAreaInsets.bottom)
-            print("new bottom inset:", inset)
             let insets = UIEdgeInsets(
                 top: 0,
                 left: 0,
@@ -86,6 +87,20 @@ final class ChatDemoViewController : UIViewController {
     @objc private func addAtBottom() {
         messages.append((UUID(), .random))
         self.reload()
+    }
+
+    @objc private func shrinkFrame() {
+        view.frame.size.height -= 22
+        reload()
+    }
+
+    @objc private func growFrame() {
+        guard view.frame.size.height < view.superview!.frame.size
+            .height else {
+            return
+        }
+        view.frame.size.height += 22
+        reload()
     }
 
     private var footerHeight: CGFloat = 80

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1716,4 +1716,24 @@ final class CollectionView : ListView.IOS16_4_First_Responder_Bug_CollectionView
 
         }
     }
+
+    override var frame: CGRect {
+        get {
+            super.frame
+        }
+        set {
+            // With bottom gravity enabled keep the scroll distance to the bottom unchanged
+            if layoutDirection == .vertical && verticalLayoutGravity == .bottom {
+                guard newValue != super.frame else {
+                    return
+                }
+                let oldValue = super.frame
+                let offsetY = contentOffset.y
+                super.frame = newValue
+                contentOffset.y = offsetY - (newValue.height - oldValue.height)
+            } else {
+                super.frame = newValue
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Before: Layout gravity doesn't take into account frame changes. For example, when the orientation changes the scroll position (relative to the bottom) changes
- After: Layout gravity takes frame changes into account so the when the frame changes the scroll position relative to the bottom remains unchanged

https://github.com/square/Listable/assets/73715873/fcf9306d-5f97-42f4-9441-43363c9e2dfe

### Checklist

Please do the following before merging:

- [ ] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
