### PR TITLE
Fix supplementary view + contained first responder reuse issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fixed an issue where supplementary views (headers or footers) that contained a first responder would result in the view being duplicated when scrolled off-screen.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.HeaderFooterState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.HeaderFooterState.swift
@@ -17,6 +17,8 @@ protocol AnyPresentationHeaderFooterState : AnyObject
     
     var oldIndexPath : IndexPath? { get }
     
+    var containsFirstResponder : Bool { get set }
+    
     func updateOldIndexPath(in section : Int)
         
     func dequeueAndPrepareReusableHeaderFooterView(
@@ -131,6 +133,8 @@ extension PresentationState
         private(set) var kind : SupplementaryKind
         
         var oldIndexPath : IndexPath? = nil
+        
+        var containsFirstResponder : Bool = false
         
         func updateOldIndexPath(in section : Int) {
             oldIndexPath = kind.indexPath(in: section)

--- a/ListableUI/Sources/Internal/UIView.swift
+++ b/ListableUI/Sources/Internal/UIView.swift
@@ -30,10 +30,4 @@ extension UIView {
         
         return nil
     }
-    
-    func isInside(superview : UIView) -> Bool {
-        
-        sequence(first: self, next: \.superview)
-            .contains(superview)
-    }
 }

--- a/ListableUI/Sources/Internal/UIView.swift
+++ b/ListableUI/Sources/Internal/UIView.swift
@@ -30,4 +30,10 @@ extension UIView {
         
         return nil
     }
+    
+    func isInside(superview : UIView) -> Bool {
+        
+        sequence(first: self, next: \.superview)
+            .contains(superview)
+    }
 }

--- a/ListableUI/Sources/Layout/ListLayout/ListLayoutContent.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayoutContent.swift
@@ -153,7 +153,7 @@ public final class ListLayoutContent
         
         // List Header
         
-        if (rect.intersects(self.header.visibleFrame) || self.header.containsFirstResponder) && include(self.header) {
+        if (rect.intersects(self.header.visibleFrame) || self.header.containsFirstResponder) && include(self.header) {            
             attributes.append(
                 .supplementary(
                     self.header,
@@ -196,7 +196,7 @@ public final class ListLayoutContent
             
             // Section Footer
             
-            if rect.intersects(section.footer.visibleFrame) && include(section.footer) {
+            if (rect.intersects(section.footer.visibleFrame) || section.footer.containsFirstResponder) && include(section.footer) {
                 attributes.append(
                     .supplementary(
                         section.footer,
@@ -208,7 +208,7 @@ public final class ListLayoutContent
         
         // List Footer
         
-        if rect.intersects(self.footer.visibleFrame) && include(self.footer) {
+        if (rect.intersects(self.footer.visibleFrame) || self.footer.containsFirstResponder) && include(self.footer) {
             attributes.append(
                 .supplementary(
                     self.footer,
@@ -220,8 +220,10 @@ public final class ListLayoutContent
         // Overscroll Footer
         
         if alwaysIncludeOverscroll || (rect.intersects(self.overscrollFooter.visibleFrame) && include(self.overscrollFooter)) {
+            
             // Don't check the rect for the overscroll view as we do with other views; it's always outside of the contentSize.
             // Instead, just return it all the time to ensure the collection view will display it when needed.
+            
             attributes.append(
                 .supplementary(
                     self.overscrollFooter,

--- a/ListableUI/Sources/Layout/ListLayout/ListLayoutContent.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayoutContent.swift
@@ -142,7 +142,7 @@ public final class ListLayoutContent
         
         // Container Header
         
-        if rect.intersects(self.containerHeader.visibleFrame) && include(self.containerHeader) {
+        if (rect.intersects(self.containerHeader.visibleFrame) || self.containerHeader.containsFirstResponder) && include(self.containerHeader) {
             attributes.append(
                 .supplementary(
                     self.containerHeader,
@@ -153,7 +153,7 @@ public final class ListLayoutContent
         
         // List Header
         
-        if rect.intersects(self.header.visibleFrame) && include(self.header) {
+        if (rect.intersects(self.header.visibleFrame) || self.header.containsFirstResponder) && include(self.header) {
             attributes.append(
                 .supplementary(
                     self.header,
@@ -172,7 +172,7 @@ public final class ListLayoutContent
             
             // Section Header
             
-            if rect.intersects(section.header.visibleFrame) && include(section.header) {
+            if (rect.intersects(section.header.visibleFrame) || section.header.containsFirstResponder) && include(section.header) {
                 attributes.append(
                     .supplementary(
                         section.header,
@@ -434,6 +434,10 @@ extension ListLayoutContent
         
         public var layouts : HeaderFooterLayouts {
             self.state?.anyModel.layouts ?? .init()
+        }
+        
+        public var containsFirstResponder : Bool {
+            self.state?.containsFirstResponder ?? false
         }
         
         public var defaultFrame : CGRect {

--- a/ListableUI/Sources/Layout/ListLayout/ListLayoutContent.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayoutContent.swift
@@ -153,7 +153,7 @@ public final class ListLayoutContent
         
         // List Header
         
-        if (rect.intersects(self.header.visibleFrame) || self.header.containsFirstResponder) && include(self.header) {            
+        if (rect.intersects(self.header.visibleFrame) || self.header.containsFirstResponder) && include(self.header) {
             attributes.append(
                 .supplementary(
                     self.header,

--- a/ListableUI/Sources/ListView/ListView.DataSource.swift
+++ b/ListableUI/Sources/ListView/ListView.DataSource.swift
@@ -57,22 +57,30 @@ internal extension ListView
             at indexPath: IndexPath
             ) -> UICollectionReusableView
         {
-            let container = SupplementaryContainerView.dequeue(
-                in: collectionView,
-                for: kind,
-                at: indexPath,
-                reuseCache: self.headerFooterReuseCache,
-                environment: self.view.environment
-            )
-            
-            let headerFooter : AnyPresentationHeaderFooterState? = {
+            let statePair : PresentationState.HeaderFooterViewStatePair = {
                 switch SupplementaryKind(rawValue: kind)! {
-                case .listContainerHeader: return self.presentationState.containerHeader.state
-                case .listHeader: return self.presentationState.header.state
-                case .listFooter: return self.presentationState.footer.state
-                case .sectionHeader: return self.presentationState.sections[indexPath.section].header.state
-                case .sectionFooter: return self.presentationState.sections[indexPath.section].footer.state
-                case .overscrollFooter: return self.presentationState.overscrollFooter.state
+                case .listContainerHeader: return self.presentationState.containerHeader
+                case .listHeader: return self.presentationState.header
+                case .listFooter: return self.presentationState.footer
+                case .sectionHeader: return self.presentationState.sections[indexPath.section].header
+                case .sectionFooter: return self.presentationState.sections[indexPath.section].footer
+                case .overscrollFooter: return self.presentationState.overscrollFooter
+                }
+            }()
+            
+            let headerFooter = statePair.state
+            
+            let container : SupplementaryContainerView = {
+                if let view = statePair.visibleContainer {
+                    return view
+                } else {
+                    return SupplementaryContainerView.dequeue(
+                        in: collectionView,
+                        for: kind,
+                        at: indexPath,
+                        reuseCache: self.headerFooterReuseCache,
+                        environment: self.view.environment
+                    )
                 }
             }()
             

--- a/ListableUI/Sources/ListView/ListView.DataSource.swift
+++ b/ListableUI/Sources/ListView/ListView.DataSource.swift
@@ -74,10 +74,16 @@ internal extension ListView
                 
                 /// Fixes a bug (https://github.com/square/Listable/pull/507) wherein
                 /// for supplementary views that contain a first responder, the collection view
-                /// seems to "forget" that there's already a supplementary view dequeued,
-                /// and ends up requesting another one, leading to a phantom "left over" supplementary
+                /// keeps them around... somewhere instead of immediately recycling the view, but then
+                /// seems to later forget that that view is already being kept around, and then
+                /// ends up requesting another view, leading to a phantom "left over" supplementary
                 /// view. Our fix is to see if we already have a visible supplementary view, and just
-                /// return it.
+                /// return it instead of dequeueing a new one.
+                ///
+                /// This is paired with a behavior change in `CollectionViewLayout`, where if a
+                /// supplementary item contains a first responder, we never remove it from the
+                /// list of items returned for the given rect, even if it's offscreen. That keeps the view
+                /// alive so we can access it here.
                 
                 if let view = statePair.visibleContainer {
                     return view

--- a/ListableUI/Sources/ListView/ListView.DataSource.swift
+++ b/ListableUI/Sources/ListView/ListView.DataSource.swift
@@ -72,20 +72,40 @@ internal extension ListView
             
             let container : SupplementaryContainerView = {
                 
-                /// Fixes a bug (https://github.com/square/Listable/pull/507) wherein
-                /// for supplementary views that contain a first responder, the collection view
-                /// keeps them around... somewhere instead of immediately recycling the view, but then
-                /// seems to later forget that that view is already being kept around, and then
-                /// ends up requesting another view, leading to a phantom "left over" supplementary
-                /// view. Our fix is to see if we already have a visible supplementary view, and just
-                /// return it instead of dequeueing a new one.
+                /// The below works around a (seeming?) bug or odd behavior in `UICollectionView`,
+                /// where it tries to be smart about recycling supplementary views that contain a
+                /// first responder such as a text field. Specifically, it holds onto a supplementary view
+                /// that contains a first responder, not immediately recycling it when it is scrolled out
+                /// of view. That ensures that the keyboard isn't immediately dismissed, which would
+                /// be jarring.
                 ///
-                /// This is paired with a behavior change in `CollectionViewLayout`, where if a
-                /// supplementary item contains a first responder, we never remove it from the
-                /// list of items returned for the given rect, even if it's offscreen. That keeps the view
-                /// alive so we can access it here. **Note**: I'd originally expected that this second
-                /// change would be sufficient to fix the issue, but it was not. Even though the supplementary
-                /// view is still alive within the collection view, it doesn't know to dequeue it properly.
+                /// ...Unfortunately, this doesn't seem to actually work in practice very well. When the
+                /// supplementary view  is scrolled back _into_ view, and we're asked to dequeue
+                /// a view, the collection view hands us back a _different_ view, leading to double
+                /// views that get stacked on top of each other in the layout, leading to a bunch
+                /// of weirdness.
+                ///
+                /// So, to work around this, we do a few things:
+                ///
+                /// 1) We begin tracking which supplementary views currently contain a first responder.
+                /// For practicality of implementation, we only track text fields right now. This could
+                /// change, but is harder, given there's no generic "first responder changed" notification.
+                /// This code lives in `ListView`.
+                ///
+                /// 2) We update `ListLayoutContent.content(in: ...)` to _always_ return
+                /// supplementary info when a supplementary view contains a first responder,
+                /// even when out of frame. This ensures the supplementary view
+                /// instance is kept alive by the collection view.
+                ///
+                /// 3) Within this method, we check to see if there's a live, existing `visibleContainer`
+                /// (aka the supplementary view) view, and if there is, we return _that_, instead of
+                /// just dequeuing a new, wrong view.
+                ///
+                /// After all that, the correct thing happens.
+                ///
+                /// PR with more info and screenshots, etc:
+                /// https://github.com/square/Listable/pull/507
+                ///
                 
                 if let view = statePair.visibleContainer {
                     return view

--- a/ListableUI/Sources/ListView/ListView.DataSource.swift
+++ b/ListableUI/Sources/ListView/ListView.DataSource.swift
@@ -71,6 +71,14 @@ internal extension ListView
             let headerFooter = statePair.state
             
             let container : SupplementaryContainerView = {
+                
+                /// Fixes a bug (https://github.com/square/Listable/pull/507) wherein
+                /// for supplementary views that contain a first responder, the collection view
+                /// seems to "forget" that there's already a supplementary view dequeued,
+                /// and ends up requesting another one, leading to a phantom "left over" supplementary
+                /// view. Our fix is to see if we already have a visible supplementary view, and just
+                /// return it.
+                
                 if let view = statePair.visibleContainer {
                     return view
                 } else {

--- a/ListableUI/Sources/ListView/ListView.DataSource.swift
+++ b/ListableUI/Sources/ListView/ListView.DataSource.swift
@@ -83,7 +83,9 @@ internal extension ListView
                 /// This is paired with a behavior change in `CollectionViewLayout`, where if a
                 /// supplementary item contains a first responder, we never remove it from the
                 /// list of items returned for the given rect, even if it's offscreen. That keeps the view
-                /// alive so we can access it here.
+                /// alive so we can access it here. **Note**: I'd originally expected that this second
+                /// change would be sufficient to fix the issue, but it was not. Even though the supplementary
+                /// view is still alive within the collection view, it doesn't know to dequeue it properly.
                 
                 if let view = statePair.visibleContainer {
                     return view

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -106,9 +106,11 @@ public final class ListView : UIView
         self.applyBehavior()
         self.updateScrollViewInsets()
         
-        // We register for first responder notifications so we can
-        // avoid recycling supplementary views that contain text fields,
-        // as this somehow breaks cell recycling.
+        /// We track first responder status in supplementary views
+        /// to fix a view recycling issue.
+        ///
+        /// See the comment in `collectionView(_:viewForSupplementaryElementOfKind:at:)
+        /// within `ListView.DataSource.swift` for more.
         
         NotificationCenter.default.addObserver(
             self,
@@ -996,7 +998,7 @@ public final class ListView : UIView
     //
     // MARK: Internal – First Responder Tracking
     //
-        
+    
     @objc private func textDidBeginEditingNotification(_ notification : Notification) {
         
         guard let field = notification.object as? UIView else {

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -105,6 +105,24 @@ public final class ListView : UIView
         self.applyAppearance()
         self.applyBehavior()
         self.updateScrollViewInsets()
+        
+        // We register for first responder notifications so we can
+        // avoid recycling supplementary views that contain text fields,
+        // as this somehow breaks cell recycling.
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(textDidBeginEditingNotification(_:)),
+            name: UITextField.textDidBeginEditingNotification,
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(textDidEndEditingNotification(_:)),
+            name: UITextField.textDidEndEditingNotification,
+            object: nil
+        )
     }
     
     deinit
@@ -973,6 +991,32 @@ public final class ListView : UIView
         
         /// Our layout changed, update the keyboard inset in case the inset should now be different.
         self.updateScrollViewInsets()
+    }
+    
+    //
+    // MARK: Internal – First Responder Tracking
+    //
+        
+    @objc private func textDidBeginEditingNotification(_ notification : Notification) {
+        
+        guard let field = notification.object as? UIView else {
+            return
+        }
+        
+        if let containingSupplementaryView = field.firstSuperview(ofType: SupplementaryContainerView.self) {
+            containingSupplementaryView.headerFooter?.containsFirstResponder = true
+        }
+    }
+    
+    @objc private func textDidEndEditingNotification(_ notification : Notification) {
+                
+        guard let field = notification.object as? UIView else {
+            return
+        }
+        
+        if let containingSupplementaryView = field.firstSuperview(ofType: SupplementaryContainerView.self) {
+            containingSupplementaryView.headerFooter?.containsFirstResponder = false
+        }
     }
     
     //


### PR DESCRIPTION
The below works around a (seeming?) bug or odd behavior in `UICollectionView`, where it tries to be smart about recycling supplementary views that contain a first responder such as a text field. Specifically, it holds onto a supplementary view that contains a first responder, not immediately recycling it when it is scrolled out of view. That ensures that the keyboard isn't immediately dismissed, which would be jarring.

...Unfortunately, this doesn't seem to actually work in practice very well. When the supplementary view  is scrolled back _into_ view, and we're asked to dequeue a view, the collection view hands us back a _different_ view, leading to double views that get stacked on top of each other in the layout, leading to a bunch of weirdness.

So, to work around this, we do a few things:

1) We begin tracking which supplementary views currently contain a first responder. For practicality of implementation, we only track text fields right now. This could change, but is harder, given there's no generic "first responder changed" notification. This code lives in `ListView`.

2) We update `ListLayoutContent.content(in: ...)` to _always_ return supplementary info when a supplementary view contains a first responder, even when out of frame. This ensures the supplementary view instance is kept alive by the collection view. You can see that happening here:

<img width="495" alt="image" src="https://github.com/square/Listable/assets/327847/ce154ba8-9f5a-4000-838c-0d551f78bd8a">

3) Within `collectionView(_:viewForSupplementaryElementOfKind:at:)`, we check to see if there's a live, existing `visibleContainer` (aka the supplementary view) view, and if there is, we return _that_, instead of just dequeuing a new, wrong view.

After all that, the correct thing happens.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
