### PR TITLE
Remove override of performBatchUpdates, it causes warnings for consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Internal
 
+- Remove override of `performBatchUpdates` from our internal `UICollectionView` subclass, it causes warnings for consumers.
+
 # Past Releases
 
 # [13.0.0] - 2023-09-06

--- a/ListableUI/Sources/ListView/ListView+iOS16.4Workaround.swift
+++ b/ListableUI/Sources/ListView/ListView+iOS16.4Workaround.swift
@@ -134,11 +134,6 @@ extension ListView {
         
         required init?(coder: NSCoder) { fatalError() }
         
-        @available(*, unavailable, message: "Please use performBatchUpdates:changes:completion:.")
-        override func performBatchUpdates(_ updates: (() -> Void)?, completion: ((Bool) -> Void)? = nil) {
-            super.performBatchUpdates(updates, completion: completion)
-        }
-        
         func performBatchUpdates(
             _ updates: @escaping () -> Void,
             changes : CollectionViewChanges,


### PR DESCRIPTION
There doesn't seem to be a way to represent `NS_NOESCAPE` in Swift here... Just going to remove this override since it's an entirely internal type anyway.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
