### PR TITLE
Update swipe actions to more closely match iOS behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- Update the swipe action interactions to more closely match iOS behavior
+- Update the swipe action interactions to more closely match iOS behavior.
 
 ### Misc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Update the swipe action interactions to more closely match iOS behavior
+
 ### Misc
 
 ### Internal

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -118,10 +118,6 @@ extension ItemCell {
             }
         }
         
-        func isTouchWithinSwipeActionView(touch: UITouch) -> Bool {
-            configurations.values.first { $0.swipeView.contains(touch: touch) } != nil
-        }
-
         // MARK: - Swipe Registration
         
         func deregisterLeadingSwipeIfNeeded() {
@@ -286,7 +282,6 @@ extension ItemCell {
         }
 
         private func set(state: SwipeActionState, animated: Bool = false) {
-
             swipeState = state
 
             if animated {

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -161,6 +161,9 @@ extension ItemCell {
 
                 let panGestureRecognizer = DirectionalPanGestureRecognizer(direction: side.gestureDirection, target: self, action: #selector(handlePan))
                 addGestureRecognizer(panGestureRecognizer)
+                let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+                tapGestureRecognizer.require(toFail: panGestureRecognizer)
+                addGestureRecognizer(tapGestureRecognizer)
 
                 configurations[side] = SwipeConfiguration(
                     panGestureRecognizer: panGestureRecognizer,
@@ -181,6 +184,11 @@ extension ItemCell {
         }
 
         private weak var listView : ListView? = nil
+
+        @objc private func handleTap(sender: UITapGestureRecognizer) {
+            // if we're tapped (and we're not panning, which is required to fail above) just close
+            set(state: .closed, animated: true)
+        }
 
         @objc private func handlePan(sender: UIPanGestureRecognizer) {
 
@@ -210,8 +218,12 @@ extension ItemCell {
                 && configuration.performsFirstActionWithFullSwipe
 
             if sender.state == .began {
-                self.listView?.liveCells.perform {
-                    $0.closeSwipeActions()
+                // If currently open, and attempting to swipe the other side, close.
+                if case let .open(currentSide) = swipeState, currentSide != side {
+                    self.performAnimatedClose()
+                    // Cancel the current pan gesture
+                    sender.isEnabled = false
+                    sender.isEnabled = true
                 }
             }
 
@@ -221,7 +233,7 @@ extension ItemCell {
                 let swipeState = SwipeActionState.swiping(side, willPerformAction: willPerformAction)
                 set(state: swipeState)
 
-            case .ended, .cancelled:
+            case .ended:
 
                 let velocity = sender.velocity(in: self).x
                 
@@ -248,6 +260,8 @@ extension ItemCell {
 
                 set(state: swipeState, animated: true)
 
+            case .cancelled:
+                set(state: .closed)
             default:
                 set(state: .closed)
 

--- a/ListableUI/Sources/Internal/ItemCell.swift
+++ b/ListableUI/Sources/Internal/ItemCell.swift
@@ -17,8 +17,6 @@ protocol AnyItemCell : UICollectionViewCell
     
     var areSwipeActionsVisible : Bool  { get }
     
-    func isTouchWithinSwipeActionView(touch: UITouch) -> Bool
-    
     func wasDequeued(with liveCells : LiveCells)
 }
 
@@ -203,10 +201,6 @@ final class ItemCell<Content:ItemContent> : UICollectionViewCell, AnyItemCell
         default:
             return false
         }
-    }
-    
-    func isTouchWithinSwipeActionView(touch: UITouch) -> Bool {
-        self.contentContainer.isTouchWithinSwipeActionView(touch: touch)
     }
     
     private var hasBeenDequeued = false

--- a/ListableUI/Sources/Internal/TouchDownGestureRecognizer.swift
+++ b/ListableUI/Sources/Internal/TouchDownGestureRecognizer.swift
@@ -30,11 +30,16 @@ final class TouchDownGestureRecognizer : UIGestureRecognizer {
         
         // We want to allow the pan gesture of our containing scroll view to continue to track
         // when the user moves their finger vertically or horizontally, when we are cancelled.
-        
         if let panGesture = gesture as? UIPanGestureRecognizer, panGesture.view is UIScrollView {
             return false
         }
-        
+
+        // We want to allow other pan gesture recognizers for swipe actions to continue to work
+        if let panGesture = gesture as? DirectionalPanGestureRecognizer {
+            return false
+        }
+
+
         return super.canPrevent(gesture)
     }
 }

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -66,7 +66,7 @@ public final class ListView : UIView
         self.collectionView.dataSource = self.dataSource
         
         self.closeActiveSwipesGesture = TouchDownGestureRecognizer()
-        
+
         self.updateQueue = ListChangesQueue()
         
         // Super init.

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1037,7 +1037,8 @@ public final class ListView : UIView
         
         guard let cell = self.liveCells.activeSwipeCell else { return false }
         
-        return cell.isTouchWithinSwipeActionView(touch: touch) == false
+        // If the user is touching down anywhere in the `activeSwipeCell` the `activeSwipeCell` will handle it.
+        return cell.contains(touch: touch) == false
     }
     
     @objc private func closeActiveSwipeGestureIfNeeded(with recognizer : UIGestureRecognizer) {


### PR DESCRIPTION
Update the swipe action interactions to better match the built in iOS behavior.

- If the swipe actions are open, and the user pans inside that cell you'll either grow the swipe actions (and possibly activate the default action) or interactively close the swipe actions.
- Touching anywhere outside of the cell with open swipe actions will close the swipe actions
- _Tapping_ inside of a cell with currently open cell will close the swipe actions.


https://github.com/square/Listable/assets/141675/780f07cf-7796-4fc2-bad8-e13a8b0e9087

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
