### PR TITLE
Fix warnings, update Blueprint version

### DIFF
--- a/ListableUI/Sources/Internal/TouchDownGestureRecognizer.swift
+++ b/ListableUI/Sources/Internal/TouchDownGestureRecognizer.swift
@@ -35,7 +35,7 @@ final class TouchDownGestureRecognizer : UIGestureRecognizer {
         }
 
         // We want to allow other pan gesture recognizers for swipe actions to continue to work
-        if let panGesture = gesture as? DirectionalPanGestureRecognizer {
+        if gesture is DirectionalPanGestureRecognizer {
             return false
         }
 

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/square/Blueprint", from: "2.0.0"),
+        .package(url: "https://github.com/square/Blueprint", from: "2.2.0"),
     ],
     targets: [
         .target(

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - BlueprintUI (2.0.0)
-  - BlueprintUICommonControls (2.0.0):
-    - BlueprintUI (= 2.0.0)
+  - BlueprintUI (2.2.0)
+  - BlueprintUICommonControls (2.2.0):
+    - BlueprintUI (= 2.2.0)
   - BlueprintUILists (13.1.0):
     - BlueprintUI (~> 2.0)
     - ListableUI
@@ -44,8 +44,8 @@ EXTERNAL SOURCES:
     :path: Internal Pods/Snapshot/Snapshot.podspec
 
 SPEC CHECKSUMS:
-  BlueprintUI: a1adeb91f76c88dd499ad693251aa96919b1c2a4
-  BlueprintUICommonControls: 9e02875bc6b8ef64aa9634c32d7156bd50c7b88d
+  BlueprintUI: 33bad09c9cc634d9e8c9df742e2616ec8629bcf9
+  BlueprintUICommonControls: 29472ce36386e43ba6d6c2b7959d0033670923f9
   BlueprintUILists: 9d0c900033505aefa08b5941844f3ed47b9993af
   EnglishDictionary: 277ff15917abc170362afbd2ad11cbe15c2ae6ad
   ListableUI: 8f2bfe37d83017d137ead278140de0393de7f588


### PR DESCRIPTION
Fixes two sets of warnings:
- unused variable warning in `TouchDownGestureRecognizer.swift`
- `UnsafeRawPointer` warning in BlueprintUI
