### PR TITLE
Match UITableView's sizing behavior for Swipe Action sizing more closely.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 ### Changed
 
 - Update the swipe action interactions to more closely match iOS behavior.
+  - Maximum button size for `.sizeThatFits` style is now 120pts
+  - Button text can span up to two lines now
+  - Automatically adjust text size for text that is too long
+  - Touching anywhere outside of the cell will close swipe actions
+  - Tapping inside of a cell with open swipe actions will close them
+  - Allow the panning gesture to remain interactive even when swipe actions are open
 
 ### Misc
 

--- a/ListableUI/Sources/Internal/SwipeActionsView.swift
+++ b/ListableUI/Sources/Internal/SwipeActionsView.swift
@@ -182,7 +182,8 @@ final class SwipeActionsView: UIView {
 
         case .sizeThatFits:
             return buttons.map {
-                max($0.sizeThatFits(UIView.layoutFittingCompressedSize).width, style.minWidth)
+                let minWidth = max($0.sizeThatFits(UIView.layoutFittingCompressedSize).width, style.minWidth)
+                return min(style.maxItemWidth, minWidth)
             }
             .reduce(0, +) + spacingWidth
         }
@@ -265,6 +266,10 @@ private class DefaultSwipeActionButton: UIButton {
 
         titleLabel?.font = .systemFont(ofSize: 15, weight: .medium)
         titleLabel?.lineBreakMode = .byTruncatingTail
+        titleLabel?.numberOfLines = 2
+        titleLabel?.minimumScaleFactor = 0.8
+        titleLabel?.adjustsFontSizeToFitWidth = true
+        titleLabel?.textAlignment = .center
         contentEdgeInsets = UIEdgeInsets(top: 0, left: inset, bottom: 0, right: inset)
         addTarget(self, action: #selector(onTap), for: .primaryActionTriggered)
     }

--- a/ListableUI/Sources/Internal/SwipeActionsViewStyle.swift
+++ b/ListableUI/Sources/Internal/SwipeActionsViewStyle.swift
@@ -32,7 +32,11 @@ public struct SwipeActionsViewStyle: Equatable {
     public var containerCornerRadius: CGFloat
     public var buttonSizing: ButtonSizing
     public var minWidth: CGFloat
-    
+
+    /// The maximum width of individual items. Defaults to 120, matching `UITableView`
+    /// - Note: Currently only applicable to `ButtonSizing.sizeThatFits` mode.
+    public var maxItemWidth: CGFloat
+
     /// The percentage of the row content width that is available for laying out swipe action buttons.
     ///
     /// For example, a value of `0.8` represents that the swipe action buttons should occupy no more than
@@ -48,7 +52,8 @@ public struct SwipeActionsViewStyle: Equatable {
         containerCornerRadius: CGFloat = 0,
         buttonSizing: ButtonSizing = .sizeThatFits,
         minWidth: CGFloat = 0,
-        maxWidthRatio: CGFloat = 0.8
+        maxWidthRatio: CGFloat = 0.8,
+        maxItemWidth: CGFloat = 120
     ) {
         self.actionShape = actionShape
         self.interActionSpacing = interActionSpacing
@@ -57,6 +62,7 @@ public struct SwipeActionsViewStyle: Equatable {
         self.containerCornerRadius = containerCornerRadius
         self.buttonSizing = buttonSizing
         self.minWidth = minWidth
+        self.maxItemWidth = maxItemWidth
         self.maxWidthRatio = maxWidthRatio
     }
 


### PR DESCRIPTION
Match `UITableView`'s behavior for sizing the swipe actions.

- Maximum button size is 120pts
- Buttons can span up to two lines, truncating at the end
- Automatically shrink text on too-long text before truncating:

UIKit:
![image](https://github.com/square/Listable/assets/141675/c02f555a-4394-457d-8df6-b87b1234f449)

These changes:
![image](https://github.com/square/Listable/assets/141675/878d6679-0674-4697-b429-338a4881ed28)


### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
