### PR TITLE
fix: don't cancel touches in view for tap gesture recognizer

### DIFF
--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -159,6 +159,7 @@ extension ItemCell {
                 addGestureRecognizer(panGestureRecognizer)
                 let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
                 tapGestureRecognizer.require(toFail: panGestureRecognizer)
+                tapGestureRecognizer.cancelsTouchesInView = false
                 addGestureRecognizer(tapGestureRecognizer)
 
                 configurations[side] = SwipeConfiguration(


### PR DESCRIPTION
The `TapGestureRecognizer` for handling the swipe actions was blocking taps. It shouldn't!

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
