### PR TITLE
fix: Fix tap gesture swallowing touches in swipe actions view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fixed a bug that resulted in some swipe action buttons not being tappable.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -12,7 +12,7 @@ extension ItemCell {
     
     private typealias Side = SwipeActionsView.Side
 
-    final class ContentContainerView : UIView {
+    final class ContentContainerView : UIView, UIGestureRecognizerDelegate {
 
         let contentView : Content.ContentView
         
@@ -159,6 +159,7 @@ extension ItemCell {
                 addGestureRecognizer(panGestureRecognizer)
                 let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
                 tapGestureRecognizer.require(toFail: panGestureRecognizer)
+                tapGestureRecognizer.delegate = self
                 tapGestureRecognizer.cancelsTouchesInView = false
                 addGestureRecognizer(tapGestureRecognizer)
 
@@ -326,6 +327,15 @@ extension ItemCell {
             swipeState = .closed
 
             setNeedsLayout()
+        }
+
+        // Mark: - UITapGestureDelegate
+        override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard let tapRecognizer = gestureRecognizer as? UITapGestureRecognizer else { return true }
+
+            // If the tap gesture is happening in the open swipe items then it shouldn't begin
+            let location = tapRecognizer.location(ofTouch: 0, in: self.contentView)
+            return self.contentView.bounds.contains(location)
         }
     }
 


### PR DESCRIPTION
There were cases in which the item `ItemCell.ContentViewContainer`'s `UITapGestureRecognizer` was swallowing touches over _some_ of the swipe action buttons. This fixes it by only allowing the gesture recognizer to begin when the touches are inside of the `contentView`.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
