### PR TITLE
reorder control now proxies accessibility into a seperate element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Main]
 
 ### Fixed
+- `ListReorderGesture` no longer blocks child accessibility, now exposing a proxy element for accessible control. 
 
 ### Added
 

--- a/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
+++ b/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
@@ -119,6 +119,65 @@ struct DemoHeader2 : BlueprintHeaderFooterContent, Equatable
 }
 
 
+struct DemoTile : BlueprintItemContent, Equatable, LocalizedCollatableItemContent
+{
+    var text : String
+    var secondaryText: String
+    
+    var identifierValue: String {
+        return "\(text) \(secondaryText)"
+    }
+    
+    func element(with info : ApplyItemContentInfo) -> Element
+    {
+        Button(onTap:{
+            print("\(text) tapped!")
+        }, wrapping: Row { row in
+            row.verticalAlignment = .center
+           
+            row.add(child:
+                Column { col in
+                    col.add(child: Label(text: text) {
+                        $0.font = .systemFont(ofSize: 17.0, weight: .medium)
+                        $0.color = info.state.isActive ? .white : .darkGray
+                    })
+                    col.add(child: Label(text: secondaryText) {
+                        $0.font = .systemFont(ofSize: 12.0, weight: .light)
+                        $0.color = info.state.isActive ? .white : .gray
+                    })
+                }
+                .inset(horizontal: 15.0, vertical: 24.0)
+            )
+        })
+        .accessibilityElement(label: text, value: secondaryText, traits: [.button])
+        .listReorderGesture(with: info.reorderingActions, begins: .onLongPress, accessibilityLabel: "Reorder \(text)")
+
+        
+    }
+    
+    func backgroundElement(with info: ApplyItemContentInfo) -> Element?
+    {
+        Box(
+            backgroundColor: info.state.isReordering ? .white(0.8) : .white,
+            cornerStyle: .rounded(radius: 8.0)
+        )
+    }
+    
+    func selectedBackgroundElement(with info: ApplyItemContentInfo) -> Element?
+    {
+        Box(
+            backgroundColor: .white(0.2),
+            cornerStyle: .rounded(radius: 8.0),
+            shadowStyle: .simple(radius: 2.0, opacity: 0.15, offset: .init(width: 0.0, height: 1.0), color: .black)
+        )
+    }
+    
+    var collationString: String {
+        return "\(text) \(secondaryText)"
+    }
+}
+
+
 struct DemoItem : BlueprintItemContent, Equatable, LocalizedCollatableItemContent
 {
     var text : String
@@ -142,10 +201,11 @@ struct DemoItem : BlueprintItemContent, Equatable, LocalizedCollatableItemConten
             
             if info.isReorderable {
                 row.addFixed(
-                    child: Image(
-                        image: UIImage(named: "ReorderControl"),
-                        contentMode: .center
-                    )
+                    child: 
+                        Image(
+                            image: UIImage(named: "ReorderControl"),
+                            contentMode: .center
+                        )
                         .listReorderGesture(with: info.reorderingActions, begins: requiresLongPress ? .onLongPress : .onTap)
                 )
             }

--- a/Demo/Sources/Demos/Demo Screens/ReorderingViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ReorderingViewController.swift
@@ -108,5 +108,23 @@ final class ReorderingViewController : ListViewController
                 item.reordering = ItemReordering(sections: .current)
             }
         }
+        
+        list += Section("5") { section in
+            section.header = DemoHeader(title: "Tile Section")
+            section.layouts.table.columns = .init(count: 2, spacing: 15.0)
+            
+            section += Item(DemoTile(text: "Item 0", secondaryText: "Section 4")) { item in
+                item.reordering = ItemReordering(sections: .current)
+            }
+            section += Item(DemoTile(text: "Item 1", secondaryText: "Section 4")) { item in
+                item.reordering = ItemReordering(sections: .current)
+            }
+            section += Item(DemoTile(text: "Item 2", secondaryText: "Section 4")) { item in
+                item.reordering = ItemReordering(sections: .current)
+            }
+            section += Item(DemoTile(text: "Item 3", secondaryText: "Section 4")) { item in
+                item.reordering = ItemReordering(sections: .current)
+            }
+        }
     }
 }

--- a/ListableUI/Sources/Item/ItemReordering.swift
+++ b/ListableUI/Sources/Item/ItemReordering.swift
@@ -161,12 +161,16 @@ extension ItemReordering {
         private var onMove : OnMove? = nil
         private var onEnd : OnEnd? = nil
         
+        // If this is set the gesture recognizer will only fire when the accessibilityProxy is selected by voiceover.
+        public var accessibilityProxy: NSObject?
+        
         /// Creates a gesture recognizer with the provided target and selector.
         public override init(target: Any?, action: Selector?)
         {
             super.init(target: target, action: action)
             
             self.addTarget(self, action: #selector(updated))
+            
             self.minimumPressDuration = 0
         }
         
@@ -206,6 +210,10 @@ extension ItemReordering {
 
         @objc private func updated()
         {
+            guard accessibilityShouldContinue() else {
+                self.state = .cancelled
+                return
+            }
             switch self.state {
             case .possible: break
             case .began:
@@ -227,6 +235,13 @@ extension ItemReordering {
                 
             @unknown default: listableInternalFatal()
             }
+        }
+        
+        private func accessibilityShouldContinue() -> Bool {
+            guard UIAccessibility.isVoiceOverRunning, let proxy = accessibilityProxy else {
+                return true
+            }
+            return UIAccessibility.focusedElement(using: .notificationVoiceOver) as? NSObject == proxy
         }
     }
 }

--- a/ListableUI/Sources/ListableLocalizedStrings.swift
+++ b/ListableUI/Sources/ListableLocalizedStrings.swift
@@ -18,7 +18,7 @@ public struct ListableLocalizedStrings {
                                                                  bundle:  .listableUIResources,
                                                                  value: "Reorder",
                                                                  comment: "Accessibility label for the reorder control on an item")
-        
+                
         public static let accessibilityHint = NSLocalizedString("reorder.AccessibilityHint",
                                                                 tableName: nil,
                                                                 bundle:  .listableUIResources,


### PR DESCRIPTION
This allows the gesture recognizer to be applied to a view without overriding its accessibility. 
Useful in situations where you'd like the gesture to apply to the entire cell for example.    

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
