### PR TITLE
Add `backgroundView` to `ListProperties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added `backgroundView` to `ListProperties`, enabling developers to set a background on their Lists.
+
 ### Removed
 
 ### Changed

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		397F72040272B0B12CAD9AEE /* Pods_Test_Targets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF78F98F7ED38C2DC8078110 /* Pods_Test_Targets.framework */; };
 		8ECEBF6228B7E4C200ECEC56 /* CenterSnappingTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ECEBF6128B7E4C200ECEC56 /* CenterSnappingTableViewController.swift */; };
 		B223A33A769988911ED5C0E1 /* Pods_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1C03134338F55F7FD12551D /* Pods_Demo.framework */; };
+		DAFC70A22BB317E100BC3074 /* ListBackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFC70A12BB317E100BC3074 /* ListBackgroundViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -112,6 +113,7 @@
 		C55FB4CC847A4E4F271441F7 /* Pods-Test Targets.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Test Targets.debug.xcconfig"; path = "Target Support Files/Pods-Test Targets/Pods-Test Targets.debug.xcconfig"; sourceTree = "<group>"; };
 		C9EC890C0D683F6A704AB9ED /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
 		CF78F98F7ED38C2DC8078110 /* Pods_Test_Targets.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Test_Targets.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAFC70A12BB317E100BC3074 /* ListBackgroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListBackgroundViewController.swift; sourceTree = "<group>"; };
 		E0E11D5AA6E2508505BEE4FC /* Pods-Test Targets.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Test Targets.release.xcconfig"; path = "Target Support Files/Pods-Test Targets/Pods-Test Targets.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -184,6 +186,7 @@
 				0AA4D9AE248064A300CF95A5 /* WidthCustomizationViewController.swift */,
 				0AC839A425EEAD110055CEF5 /* OnTapItemAnimationViewController.swift */,
 				2B5691392846737C00E575BE /* AutoScrollingViewController2.swift */,
+				DAFC70A12BB317E100BC3074 /* ListBackgroundViewController.swift */,
 			);
 			path = "Demo Screens";
 			sourceTree = "<group>";
@@ -465,6 +468,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAFC70A22BB317E100BC3074 /* ListBackgroundViewController.swift in Sources */,
 				0AA4D9BE248064A300CF95A5 /* DemosRootViewController.swift in Sources */,
 				0AD0CF6728B57759000ECF0C /* SupplementaryTestingViewController.swift in Sources */,
 				0A57BA2D274FFCE000A118BD /* FlowLayoutViewController.swift in Sources */,

--- a/Demo/Sources/Demos/Demo Screens/ListBackgroundViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/ListBackgroundViewController.swift
@@ -1,0 +1,55 @@
+//
+//  AutoScrollingViewController2.swift
+//  Demo
+//
+//  Created by Blake McAnally on 3/26/24.
+//  Copyright © 2022 Kyle Van Essen. All rights reserved.//
+
+import UIKit
+
+import ListableUI
+import BlueprintUILists
+import BlueprintUI
+import BlueprintUICommonControls
+
+final class ListBackgroundViewController: UIViewController {
+    let list = ListView()
+    
+    let background: UIImageView = {
+        let image = UIImageView(
+            image: UIImage(named: "kyle")
+        )
+        image.contentMode = .scaleAspectFit
+        return image
+    }()
+
+    override func loadView()
+    {
+        self.view = self.list
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.list.configure { properties in
+            
+            properties.backgroundView = background
+            
+            properties.add {
+                Section("items") {
+                    AutoLayoutContent(
+                        header: "Foo",
+                        detail: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio urna, volutpat vitae volutpat quis, auctor ut purus. Pellentesque ac varius metus."
+                    )
+                    AutoLayoutContent(
+                        header: "Bar",
+                        detail: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio urna, volutpat vitae volutpat quis, auctor ut purus. Pellentesque ac varius metus."
+                    )
+                    AutoLayoutContent(
+                        header: "Baz",
+                        detail: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio urna, volutpat vitae volutpat quis, auctor ut purus. Pellentesque ac varius metus."
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -366,6 +366,18 @@ public final class DemosRootViewController : ListViewController
             } header: {
                 DemoHeader(title: "UIScrollViews")
             }
+            
+            Section("list-background") { [weak self] in
+                Item(
+                    DemoItem(text: "Background View"),
+                    selectionStyle: .selectable(),
+                    onSelect : { _ in
+                        self?.push(ListBackgroundViewController())
+                    }
+                )
+            } header: {
+                DemoHeader(title: "backgroundView")
+            }
         }
     }
 }

--- a/ListableUI/Sources/EmbeddedList.swift
+++ b/ListableUI/Sources/EmbeddedList.swift
@@ -80,6 +80,7 @@ public struct EmbeddedList : ItemContent
             appearance: .init {
                 $0.showsScrollIndicators = false
             },
+            backgroundView: nil,
             scrollIndicatorInsets: .init(),
             behavior: .init(),
             autoScrollAction: .none,

--- a/ListableUI/Sources/ListProperties.swift
+++ b/ListableUI/Sources/ListProperties.swift
@@ -92,6 +92,9 @@ import UIKit
     /// The appearance to use with the list.
     public var appearance : Appearance
     
+    /// The view to use as the background of the list view.
+    public var backgroundView : UIView?
+    
     /// The scroll insets to apply to the list view.
     public var scrollIndicatorInsets : UIEdgeInsets
     
@@ -161,6 +164,7 @@ import UIKit
             animatesChanges: UIView.inheritedAnimationDuration > 0.0,
             layout: .table(),
             appearance: .init(),
+            backgroundView: nil,
             scrollIndicatorInsets: .zero,
             behavior: .init(),
             autoScrollAction: .none,
@@ -176,6 +180,7 @@ import UIKit
         animatesChanges: Bool,
         layout : LayoutDescription,
         appearance : Appearance,
+        backgroundView: UIView?,
         scrollIndicatorInsets : UIEdgeInsets,
         behavior : Behavior,
         autoScrollAction : AutoScrollAction,
@@ -187,6 +192,7 @@ import UIKit
         self.animatesChanges = animatesChanges
         self.layout = layout
         self.appearance = appearance
+        self.backgroundView = backgroundView
         self.scrollIndicatorInsets = scrollIndicatorInsets
         self.behavior = behavior
         self.autoScrollAction = autoScrollAction

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -840,6 +840,7 @@ public final class ListView : UIView
             animatesChanges: true,
             layout: self.layout,
             appearance: self.appearance,
+            backgroundView: self.backgroundView,
             scrollIndicatorInsets: self.scrollIndicatorInsets,
             behavior: self.behavior,
             autoScrollAction: self.autoScrollAction,
@@ -872,6 +873,7 @@ public final class ListView : UIView
             self.onKeyboardFrameWillChange = properties.onKeyboardFrameWillChange
             self.scrollIndicatorInsets = properties.scrollIndicatorInsets
             self.collectionView.accessibilityIdentifier = properties.accessibilityIdentifier
+            self.collectionView.backgroundView = properties.backgroundView
             self.debuggingIdentifier = properties.debuggingIdentifier
             self.actions = properties.actions
 
@@ -970,6 +972,12 @@ public final class ListView : UIView
     public override var backgroundColor: UIColor? {
         didSet {
             self.collectionView.backgroundColor = self.backgroundColor
+        }
+    }
+    
+    public var backgroundView: UIView? {
+        didSet {
+            self.collectionView.backgroundView = self.backgroundView
         }
     }
     


### PR DESCRIPTION
Adds `ListProperties.backgroundView` to enable developers to set a background on the underlying `UICollectionView`. This can be useful for more detailed layouts.

### Screenshots

<img width="565" alt="Screenshot 2024-03-26 at 10 15 05 AM" src="https://github.com/square/Listable/assets/92325654/cbc0df76-d113-493b-8366-73a4cf7000b8">

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
