### PR TITLE
Prepare 14.2.0 release, which contains a Blueprint update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 # Past Releases
 
+# [14.2.0] – 2024-04-29
+
+### Internal
+
+- `BlueprintUILists` now depends on `BlueprintUI` 4.0.0.
+
 # [14.1.0] – 2024-03-28
 
 ### Fixed
@@ -1033,7 +1039,8 @@ listActions.scrolling.scrollToSection(
 Earlier releases were ad-hoc and not tracked. To see all changes, please reference [closed PRs on Github](https://github.com/kyleve/Listable/pulls?q=is%3Apr+is%3Aclosed).
 
 
-[Main]: https://github.com/square/Listable/compare/14.1.0...main
+[Main]: https://github.com/square/Listable/compare/14.2.0...main
+[14.2.0]: https://github.com/square/Listable/compare/14.1.0...14.2.0
 [14.1.0]: https://github.com/square/Listable/compare/14.0.3...14.1.0
 [14.0.3]: https://github.com/square/Listable/compare/14.0.2...14.0.3
 [14.0.2]: https://github.com/square/Listable/compare/14.0.1...14.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.6)
+    CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
-    activesupport (7.1.3)
+    activesupport (7.1.3.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -38,7 +40,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.2.0)
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.7)
     claide (1.1.0)
     cocoapods (1.15.2)
       addressable (~> 2.8)
@@ -91,8 +93,7 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     emoji_regex (3.2.3)
     escape (0.0.4)
     ethon (0.16.0)
@@ -212,7 +213,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     jazzy (0.14.4)
       cocoapods (~> 1.5)
@@ -225,13 +226,13 @@ GEM
       sqlite3 (~> 1.3)
       xcinvoke (~> 0.3.0)
     jmespath (1.6.2)
-    json (2.7.1)
+    json (2.7.2)
     jwt (2.7.1)
     liferaft (0.0.6)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.22.2)
+    minitest (5.22.3)
     molinillo (0.8.0)
     multi_json (1.15.0)
     multipart-post (2.4.0)
@@ -241,6 +242,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
+    nkf (0.2.0)
     open4 (1.3.4)
     optparse (0.4.0)
     os (1.1.4)

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/square/Blueprint",
       "state" : {
-        "revision" : "b8acc6f183fa0d3c0c916a2e4fe0e0db77adc801",
-        "version" : "2.2.0"
+        "revision" : "93ccf388f656db030750ac2a895dc80205e5ae20",
+        "version" : "4.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/square/Blueprint", from: "3.0.0"),
+        .package(url: "https://github.com/square/Blueprint", from: "4.0.0"),
     ],
     targets: [
         .target(

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - BlueprintUI (3.0.0)
-  - BlueprintUICommonControls (3.0.0):
-    - BlueprintUI (= 3.0.0)
+  - BlueprintUI (4.0.0)
+  - BlueprintUICommonControls (4.0.0):
+    - BlueprintUI (= 4.0.0)
   - BlueprintUILists (14.1.0):
-    - BlueprintUI (~> 3.0)
+    - BlueprintUI (~> 4.0)
     - ListableUI
   - BlueprintUILists/Tests (14.1.0):
-    - BlueprintUI (~> 3.0)
-    - BlueprintUICommonControls (~> 3.0)
+    - BlueprintUI (~> 4.0)
+    - BlueprintUICommonControls (~> 4.0)
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
   - ListableUI (14.1.0)
@@ -44,9 +44,9 @@ EXTERNAL SOURCES:
     :path: Internal Pods/Snapshot/Snapshot.podspec
 
 SPEC CHECKSUMS:
-  BlueprintUI: 76e054862aceb2b014a7953464c5769af55c13d5
-  BlueprintUICommonControls: 9219a0b82ea4b95bbeef44d3fbc65b9b01f1acba
-  BlueprintUILists: 536161917b936281550ef22f3a712c8bccea529a
+  BlueprintUI: 1818f187a6be6c69266a4e30f03a6ad7755530e9
+  BlueprintUICommonControls: 6ceffc16822dea3d1910029aa87eed7a386e4e3b
+  BlueprintUILists: 1bd504b26a67af92c55c1b585e9225ed48e8d1b0
   EnglishDictionary: 2cf40d33cc1b68c4152a1cc69561aaf6e4ba0209
   ListableUI: a72a791be89be6fd301c692e9792e4e0eff9c5d7
   Snapshot: 574e65b08c02491a541efbd2619c92cc26514d1c

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= ['~> 3.0'].freeze
+BLUEPRINT_VERSION ||= ['~> 4.0'].freeze
 
 LISTABLE_VERSION ||= '14.1.0'
 


### PR DESCRIPTION
### Internal

- `BlueprintUILists` now depends on `BlueprintUI` 4.0.0.