### PR TITLE
Revert cell animation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Removed
 
+- Revert: Fixed an issue where animations would occur when dequeuing / reusing cells. A layout is now forced without animation before presentation.
+
 ### Changed
 
 ### Misc

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0A07119324BA798400CDF65D /* ListStateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A07119224BA798400CDF65D /* ListStateViewController.swift */; };
 		0A0E070423870A5700DDD27D /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 0A0E070323870A5700DDD27D /* README.md */; };
 		0A1306E7272F29B300F6DDDD /* BestPractices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1306E6272F29B300F6DDDD /* BestPractices.swift */; };
+		0A42B4EA2C66C31A003117B0 /* AnimatedReuseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A42B4E92C66C31A003117B0 /* AnimatedReuseViewController.swift */; };
 		0A49210424E5E11300D17038 /* AccordionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A49210324E5E11300D17038 /* AccordionViewController.swift */; };
 		0A57BA2D274FFCE000A118BD /* FlowLayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A57BA2C274FFCE000A118BD /* FlowLayoutViewController.swift */; };
 		0A5DC1A924F6FD4200DC7C14 /* ListAppearsAfterKeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5DC1A824F6FD4200DC7C14 /* ListAppearsAfterKeyboardViewController.swift */; };
@@ -63,6 +64,7 @@
 		0A0E070323870A5700DDD27D /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		0A1306E6272F29B300F6DDDD /* BestPractices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BestPractices.swift; sourceTree = "<group>"; };
 		0A1306EA272F762500F6DDDD /* TASKLIST.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = TASKLIST.md; path = ../TASKLIST.md; sourceTree = "<group>"; };
+		0A42B4E92C66C31A003117B0 /* AnimatedReuseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedReuseViewController.swift; sourceTree = "<group>"; };
 		0A49210324E5E11300D17038 /* AccordionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccordionViewController.swift; sourceTree = "<group>"; };
 		0A57BA2C274FFCE000A118BD /* FlowLayoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayoutViewController.swift; sourceTree = "<group>"; };
 		0A5DC1A824F6FD4200DC7C14 /* ListAppearsAfterKeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAppearsAfterKeyboardViewController.swift; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 				0A02B2F32675E14600B3501B /* PaymentTypesViewController.swift */,
 				1F46FB6A26010F4900760961 /* RefreshControlOffsetAdjustmentViewController.swift */,
 				0AA4D9AA248064A200CF95A5 /* ScrollViewEdgesPlaygroundViewController.swift */,
+				0A42B4E92C66C31A003117B0 /* AnimatedReuseViewController.swift */,
 				0A793B5724E4B53500850139 /* ManualSelectionManagementViewController.swift */,
 				2B8804642490844A003BB351 /* SpacingCustomizationViewController.swift */,
 				0AA4D9B5248064A300CF95A5 /* SwipeActionsViewController.swift */,
@@ -487,6 +490,7 @@
 				0AA4D9BC248064A300CF95A5 /* KeyboardTestingViewController.swift in Sources */,
 				0AA4D9C1248064A300CF95A5 /* CoordinatorViewController.swift in Sources */,
 				0A49210424E5E11300D17038 /* AccordionViewController.swift in Sources */,
+				0A42B4EA2C66C31A003117B0 /* AnimatedReuseViewController.swift in Sources */,
 				0A1306E7272F29B300F6DDDD /* BestPractices.swift in Sources */,
 				0AA4D9C3248064A300CF95A5 /* CollectionViewAppearance.swift in Sources */,
 				2B8804652490844A003BB351 /* SpacingCustomizationViewController.swift in Sources */,

--- a/Demo/Sources/Demos/Demo Screens/AnimatedReuseViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/AnimatedReuseViewController.swift
@@ -1,0 +1,39 @@
+//
+//  AnimatedReuseViewController.swift
+//  Demo
+//
+//  Created by Kyle Van Essen on 8/9/24.
+//  Copyright © 2024 Kyle Van Essen. All rights reserved.
+//
+
+import BlueprintUILists
+import BlueprintUICommonControls
+
+
+final class AnimatedReuseViewController : ListViewController {
+    
+    
+    override func configure(list: inout ListProperties) {
+        
+        list.add {
+            Section("items") {
+                for row in 1...1000 {
+                    ToggleRow(isOn: .random(), identifierValue: row)
+                }
+            }
+        }
+    }
+    
+    private struct ToggleRow : BlueprintItemContent, Equatable {
+        
+        var isOn: Bool
+        var identifierValue: AnyHashable
+        
+        func element(with info: ApplyItemContentInfo) -> any Element {
+            Toggle(isOn: isOn) { _ in }
+                .centered()
+                .inset(uniform: 10)
+        }
+        
+    }
+}

--- a/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
+++ b/Demo/Sources/Demos/Demo Screens/CollectionViewAppearance.swift
@@ -269,7 +269,7 @@ struct Toggle : Element {
             
             config.apply { toggle in
                 if toggle.isOn != self.isOn {
-                    toggle.setOn(self.isOn, animated: UIView.inheritedAnimationDuration > 0.0)
+                    toggle.setOn(self.isOn, animated: true)
                 }
                 toggle.onToggle = self.onToggle
             }

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -302,7 +302,7 @@ public final class DemosRootViewController : ListViewController
                 DemoHeader(title: "Other Layouts")
             }
             
-            Section("fuzzing") { [weak self] in
+            Section("testing") { [weak self] in
 
                 Item(
                     DemoItem(text: "Fuzz Testing"),
@@ -319,8 +319,16 @@ public final class DemosRootViewController : ListViewController
                         self?.push(SupplementaryTestingViewController())
                     }
                 )
+                
+                Item(
+                    DemoItem(text: "Verify Reuse Has No Animation"),
+                    selectionStyle: .selectable(),
+                    onSelect : { _ in
+                        self?.push(AnimatedReuseViewController())
+                    }
+                )
             } header: {
-                DemoHeader(title: "Fuzz Testing")
+                DemoHeader(title: "Testing")
             }
             
             Section("selection-state") {

--- a/ListableUI/Sources/ListView/ListView.Delegate.swift
+++ b/ListableUI/Sources/ListView/ListView.Delegate.swift
@@ -140,13 +140,6 @@ extension ListView
             item.willDisplay(cell: cell, in: collectionView, for: indexPath)
             
             self.displayedItems[ObjectIdentifier(cell)] = item
-            
-            UIView.performWithoutAnimation {
-                /// Force a layout of the cell before it is displayed, so that any implicit animations
-                /// are avoided. This ensures that cases like toggling a switch on and off are
-                /// not animated as the cell comes into view.
-                cell.layoutIfNeeded()
-            }
         }
         
         func collectionView(
@@ -182,13 +175,6 @@ extension ListView
             headerFooter.collectionViewWillDisplay(view: container)
             
             self.displayedSupplementaryItems[ObjectIdentifier(container)] = headerFooter
-            
-            UIView.performWithoutAnimation {
-                /// Force a layout of the cell before it is displayed, so that any implicit animations
-                /// are avoided. This ensures that cases like toggling a switch on and off are
-                /// not animated as the cell comes into view.
-                container.layoutIfNeeded()
-            }
         }
         
         func collectionView(


### PR DESCRIPTION
This reverts out the fixes from https://github.com/square/Listable/pull/517, since it breaks our KIF tests in POS. I missed this previously due to test selection. I've also added a testing VC to iterate on this more.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
