### PR TITLE
fix: Remove static view caching to improve memory management

### DIFF
--- a/ListableUI/Sources/Layout/ListLayout/ListLayout+Layout.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayout+Layout.swift
@@ -11,9 +11,6 @@ import UIKit
 
 extension ListProperties {
     
-    private static let headerFooterMeasurementCache = ReusableViewCache()
-    private static let itemMeasurementCache = ReusableViewCache()
-    
     /// **Note**: For testing or measuring content sizes only.
     ///
     /// Uses the properties from the list properties to create a `PresentationState`
@@ -37,8 +34,8 @@ extension ListProperties {
                 }
             }(),
             environment: self.environment,
-            itemMeasurementCache: Self.itemMeasurementCache,
-            headerFooterMeasurementCache: Self.headerFooterMeasurementCache
+            itemMeasurementCache: ReusableViewCache(),
+            headerFooterMeasurementCache: ReusableViewCache()
         )
         
         /// 2) Create the layout used to measure the content.

--- a/ListableUI/Sources/ListView/ListView+ContentSize.swift
+++ b/ListableUI/Sources/ListView/ListView+ContentSize.swift
@@ -13,10 +13,7 @@ extension ListView
     //
     // MARK: Measuring Lists
     //
-    
-    static let headerFooterMeasurementCache = ReusableViewCache()
-    static let itemMeasurementCache = ReusableViewCache()
-    
+
     public static let defaultContentSizeItemLimit = 50
     
     ///

--- a/ListableUI/Sources/ListView/ListView.Delegate.swift
+++ b/ListableUI/Sources/ListView/ListView.Delegate.swift
@@ -15,12 +15,7 @@ extension ListView
         unowned var view : ListView!
         unowned var presentationState : PresentationState!
         unowned var layoutManager : LayoutManager!
-        
-        private let itemMeasurementCache = ReusableViewCache()
-        private let headerFooterMeasurementCache = ReusableViewCache()
-        
-        private let headerFooterViewCache = ReusableViewCache()
-        
+
         // MARK: UICollectionViewDelegate
         
         func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool


### PR DESCRIPTION
- **Remove static caches from ListProperties**
- **Remove unused static cache vars**

The static `ReusableViewCache`s used in `ListProperties` would cause views to be retained beyond the lifetime of the owning list and if the views themselves referenced other objects (directly or through closures) then large parts of application state could be inadvertently "leaked" for the lifetime of the application.

This change instantiates new caches every time `PresentationState` is instantiated. There is a measuring performance impact since each reuse identifier will need to be recreated once per layout. On a long homogenous list that probably isn't a big deal, but for a heterogenous list it could be more of an issue (in the extreme case of a list composed of unique cells for every row this caching would provide no benefit). I haven't done any formal profiling on this.

Ideally we'd be able to associate the caches to the list views themselves so that their lifetimes were bound together. That would help avoid many of the memory issues we've seen while improving the cache effectiveness.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
