### PR TITLE
feat: Introduce CacheClearer to force-clear static caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added `CacheCleaner` which exposes a method to force Listable's static caches to be cleared. 
+
 ### Removed
 
 ### Changed

--- a/CacheClearer.swift
+++ b/CacheClearer.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+@_spi(CacheManagement)
+public struct CacheClearer {
+
+    /// Clears all static caches that are in use.
+    ///
+    /// Listable leverages static caching to improve performance however there are situations in which
+    /// this can cause object lifetimes to be extended unexpectedly, especially in cases where cached
+    /// views reference other objects.
+    ///
+    /// - WARNING: Clearing these caches can have global performance implications. This method
+    /// should be invoked sparingley and only after other workarounds to manage object lifetimes have failed.
+    @_spi(CacheManagement)
+    public static func clearStaticCaches() {
+        ListProperties.headerFooterMeasurementCache.removeAllObjects()
+        ListProperties.itemMeasurementCache.removeAllObjects()
+    }
+}

--- a/CacheClearerTests.swift
+++ b/CacheClearerTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable @_spi(CacheManagement) import ListableUI
+
+class CacheClearerTests: XCTestCase {
+
+    func test_clearStaticCaches() {
+
+        ListProperties.headerFooterMeasurementCache.push(UIView(), with: .identifier(for: UIView.self))
+        ListProperties.itemMeasurementCache.push(UIView(), with: .identifier(for: UIView.self))
+
+        XCTAssertEqual(ListProperties.headerFooterMeasurementCache.cachedViewCount, 1)
+        XCTAssertEqual(ListProperties.itemMeasurementCache.cachedViewCount, 1)
+
+        CacheClearer.clearStaticCaches()
+        
+        XCTAssertEqual(ListProperties.headerFooterMeasurementCache.cachedViewCount, 0)
+        XCTAssertEqual(ListProperties.itemMeasurementCache.cachedViewCount, 0)
+    }
+}

--- a/ListableUI/Sources/Internal/ReusableViewCache.swift
+++ b/ListableUI/Sources/Internal/ReusableViewCache.swift
@@ -11,7 +11,11 @@ import Foundation
 final class ReusableViewCache
 {
     private var views : [String:[AnyObject]] = [:]
-    
+
+    var cachedViewCount : Int {
+        return self.views.values.reduce(0) { $0 + $1.count }
+    }
+
     init() {}
     
     func count<Content>(for reuseIdentifier : ReuseIdentifier<Content>) -> Int
@@ -60,5 +64,9 @@ final class ReusableViewCache
             
             return result
         }
+    }
+
+    func removeAllObjects() {
+        self.views = [:]
     }
 }

--- a/ListableUI/Sources/Layout/ListLayout/ListLayout+Layout.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayout+Layout.swift
@@ -11,8 +11,8 @@ import UIKit
 
 extension ListProperties {
     
-    private static let headerFooterMeasurementCache = ReusableViewCache()
-    private static let itemMeasurementCache = ReusableViewCache()
+    static let headerFooterMeasurementCache = ReusableViewCache()
+    static let itemMeasurementCache = ReusableViewCache()
     
     /// **Note**: For testing or measuring content sizes only.
     ///

--- a/ListableUI/Sources/ListView/ListView+ContentSize.swift
+++ b/ListableUI/Sources/ListView/ListView+ContentSize.swift
@@ -14,9 +14,6 @@ extension ListView
     // MARK: Measuring Lists
     //
     
-    static let headerFooterMeasurementCache = ReusableViewCache()
-    static let itemMeasurementCache = ReusableViewCache()
-    
     public static let defaultContentSizeItemLimit = 50
     
     ///

--- a/ListableUI/Sources/ListView/ListView.Delegate.swift
+++ b/ListableUI/Sources/ListView/ListView.Delegate.swift
@@ -16,11 +16,6 @@ extension ListView
         unowned var presentationState : PresentationState!
         unowned var layoutManager : LayoutManager!
         
-        private let itemMeasurementCache = ReusableViewCache()
-        private let headerFooterMeasurementCache = ReusableViewCache()
-        
-        private let headerFooterViewCache = ReusableViewCache()
-        
         // MARK: UICollectionViewDelegate
         
         func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool

--- a/ListableUI/Tests/Internal/ReusableViewCacheTests.swift
+++ b/ListableUI/Tests/Internal/ReusableViewCacheTests.swift
@@ -168,6 +168,36 @@ class ReusableViewCacheTests: XCTestCase
             XCTAssertEqual(result, "result")
         }
     }
+
+    func test_removeAllObjects() {
+        self.testcase("empty") {
+            let cache = ReusableViewCache()
+            
+            XCTAssertEqual(cache.cachedViewCount, 0)
+
+            cache.removeAllObjects()
+
+            XCTAssertEqual(cache.cachedViewCount, 0)
+        }
+
+        self.testcase("non-empty") {
+            let cache = ReusableViewCache()
+
+            let view1 = TestView1()
+            view1.identifier = "pushed_1"
+            cache.push(view1, with: ReuseIdentifier.identifier(for: TestView1.self))
+
+            let view2 = TestView1()
+            view2.identifier = "pushed_2"
+            cache.push(view2, with: ReuseIdentifier.identifier(for: TestView1.self))
+
+            XCTAssertEqual(cache.cachedViewCount, 2)
+
+            cache.removeAllObjects()
+
+            XCTAssertEqual(cache.cachedViewCount, 0)
+        }
+    }
 }
 
 


### PR DESCRIPTION
- **Introduce CacheClearer to force clear static caches**
- **Remove unused static caches**
- **Update CHANGELOG.md**

Allows clients to force-clear the static caches used in Listable. This intended as a stop-gap solution (famous last words, I know) until work is done to scope the cache lifetimes more appropriately.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/kyleve/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
