### PR TITLE
Fix for crash when doing a programmatic scroll down while another external update is processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Disabled cell content interaction when swipe actions were visible.
+- Fixed a crash which could occur when a programmatic scroll down event is quickly followed by a content update.
 
 ### Added
 

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1057,6 +1057,7 @@ public final class ListView : UIView
         
         let indexPaths = self.collectionView.indexPathsForVisibleItems
         
+        // TODO: Pick biggest index path here? Does it matter?
         let indexPath = updateOverrideIndexPath ?? indexPaths.first
         
         let presentationStateTruncated = self.storage.presentationState.containsAllItems == false

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1042,6 +1042,8 @@ public final class ListView : UIView
     // MARK: Internal - Updating Presentation State
     //
     
+    private var updateOverrideIndexPath : IndexPath? = nil
+    
     internal func updatePresentationState(
         for reason : PresentationState.UpdateReason,
         completion callerCompletion : @escaping (Bool) -> () = { _ in }
@@ -1055,7 +1057,7 @@ public final class ListView : UIView
         
         let indexPaths = self.collectionView.indexPathsForVisibleItems
         
-        let indexPath = indexPaths.first
+        let indexPath = updateOverrideIndexPath ?? indexPaths.first
         
         let presentationStateTruncated = self.storage.presentationState.containsAllItems == false
         
@@ -1090,7 +1092,13 @@ public final class ListView : UIView
             self.updatePresentationStateWith(firstVisibleIndexPath: indexPath, for: reason, completion: completion)
             
         case .programaticScrollDownTo(let scrollToIndexPath):
-            self.updatePresentationStateWith(firstVisibleIndexPath: scrollToIndexPath, for: reason, completion: completion)
+            
+            updateOverrideIndexPath = scrollToIndexPath
+            
+            self.updatePresentationStateWith(firstVisibleIndexPath: scrollToIndexPath, for: reason, completion: {
+                self.updateOverrideIndexPath = nil
+                completion($0)
+            })
         }
     }
         

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1097,7 +1097,14 @@ public final class ListView : UIView
             updateOverrideIndexPath = scrollToIndexPath
             
             self.updatePresentationStateWith(firstVisibleIndexPath: scrollToIndexPath, for: reason, completion: {
-                self.updateOverrideIndexPath = nil
+                
+                /// Verify this is the same as inputted index path – if it's not, that means
+                /// _another_ `programaticScrollDownTo` has occurred and thus has
+                /// overridden this value, so we shouldn't clear it out.
+                if self.updateOverrideIndexPath == scrollToIndexPath {
+                    self.updateOverrideIndexPath = nil
+                }
+
                 completion($0)
             })
         }

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1050,22 +1050,22 @@ public final class ListView : UIView
     private var updateOverrideIndexPath : IndexPath? = nil
     
     private var firstVisibleIndexPath : IndexPath? {
-        
+
         /// 1) Get the first visible index path.
-        
+
         let visibleIndexPaths = self.collectionView.indexPathsForVisibleItems.sorted(by: <)
-        
+
         /// 2) Pick the largest index path of two to return.
-        
+
         return [
             updateOverrideIndexPath,
             visibleIndexPaths.first
         ]
-        .compactMap(\.self)
-        .sorted(by: >)
-        .first
+            .compactMap { $0 }
+            .sorted(by: >)
+            .first
     }
-    
+
     internal func updatePresentationState(
         for reason : PresentationState.UpdateReason,
         completion callerCompletion : @escaping (Bool) -> () = { _ in }

--- a/ListableUI/Tests/ListView/ListViewTests.swift
+++ b/ListableUI/Tests/ListView/ListViewTests.swift
@@ -565,6 +565,51 @@ class ListViewTests: XCTestCase
         }
     }
     
+    func test_updatePresentationState_respects_index_path_from_programaticScrollDownTo() {
+                
+        let content = Content { content in
+
+            for sectionID in 1...50 {
+                content += Section(sectionID) {
+                    for itemID in 1...20 {
+                        TestContent(content: itemID)
+                    }
+                }
+            }
+        }
+
+        let vc = ViewController()
+
+        show(vc: vc) { vc in
+            self.waitFor {
+
+                vc.list.configure { list in
+                    list.content = content
+                }
+                
+                /// The bug occurs when we try to scroll down, and then quickly try to deliver another
+                /// update while the scroll event is in progress/enqueued, so the visible index paths
+                /// haven't updated yet.
+                
+                vc.list.scrollToSection(
+                    with: Section.identifier(with: 45),
+                    scrollPosition: .init(position: .bottom),
+                    animated: true
+                )
+                
+                /// Ok, now push through another update.
+                
+                vc.list.configure { list in
+                    list.content = content
+                }
+
+                /// Don't return until the list queue is empty.
+                return vc.list.updateQueue.isEmpty
+            }
+        }
+        
+    }
+    
     func test_auto_scroll_action() {
         
         self.testcase("on insert") {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,16 +2,16 @@ PODS:
   - BlueprintUI (5.0.0)
   - BlueprintUICommonControls (5.0.0):
     - BlueprintUI (= 5.0.0)
-  - BlueprintUILists (14.5.0):
+  - BlueprintUILists (15.0.0):
     - BlueprintUI (~> 5.0)
     - ListableUI
-  - BlueprintUILists/Tests (14.5.0):
+  - BlueprintUILists/Tests (15.0.0):
     - BlueprintUI (~> 5.0)
     - BlueprintUICommonControls (~> 5.0)
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
-  - ListableUI (14.5.0)
-  - ListableUI/Tests (14.5.0):
+  - ListableUI (15.0.0)
+  - ListableUI/Tests (15.0.0):
     - EnglishDictionary
     - Snapshot
   - Snapshot (1.0.0.LOCAL)
@@ -46,11 +46,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BlueprintUI: 0e2d2944bca6c0d6d96df711a43bce01154bb7ef
   BlueprintUICommonControls: 8f400ee3ecf2bc58bd21cce29caba9f7c83d22b8
-  BlueprintUILists: 4117df302af98c741a418b56a283d0c7789ab102
+  BlueprintUILists: cfb6d749c30c0c1e284b6023d2dc896a867b1be1
   EnglishDictionary: 2cf40d33cc1b68c4152a1cc69561aaf6e4ba0209
-  ListableUI: 3f5bc50d23beb8386958d4c9729f5bd2fb6b4b68
+  ListableUI: 3a11aff2002d49910bbcd6bd68ed87d9b2f28b4d
   Snapshot: 574e65b08c02491a541efbd2619c92cc26514d1c
 
 PODFILE CHECKSUM: 2b979d4f2436d28af7c87b125b646836119b89b7
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2


### PR DESCRIPTION
This fixes an issue with multiple updates coming in close to each other and accidentally "undoing" the programmatic scroll down event that was previously enqueued. The fix is to instead of just referencing the first visible index path when processing further updates, to use the in-progress index path from the prior programmatic scroll event.

I've added a test that fails without the fix.

https://block.atlassian.net/browse/UI-8010

### Checklist

Please do the following before merging:

- [x] Unit tests
- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
