### PR TITLE
Updating actions cache version

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -75,7 +75,7 @@ jobs:
       # Build Caching
 
       - name: Cache Cocoapods
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Internal
 
+- Updating GitHub `actions/cache` to v4.
+
 # Past Releases
 
 # [15.0.1] - 2025-02-25


### PR DESCRIPTION
This moves us off of `actions/cache` v2 which is no longer supported.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
