### PR TITLE
bug: Disable cell content interaction while swipe actions are visible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Disabled cell content interaction when swipe actions were visible.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -15,7 +15,7 @@ extension ItemCell {
     final class ContentContainerView : UIView, UIGestureRecognizerDelegate {
 
         let contentView : Content.ContentView
-        
+
         private var configurations: [Side: SwipeConfiguration] = [:]
         
         private var swipeAccessibilityCustomActions: [Side: [AccessibilitySwipeAction]] = [:] {
@@ -24,7 +24,7 @@ extension ItemCell {
             }
         }
 
-        private (set) var swipeState: SwipeActionState = .closed {
+        private(set) var swipeState: SwipeActionState = .closed {
             didSet {
                 if oldValue != swipeState {
                     configurations.values.forEach { $0.swipeView.apply(state: swipeState) }
@@ -285,6 +285,14 @@ extension ItemCell {
 
         private func set(state: SwipeActionState, animated: Bool = false) {
             swipeState = state
+
+            // We don't want any actions on the content view while our swipe actions are open.
+            self.contentView.isUserInteractionEnabled = switch state {
+            case .closed:
+                true
+            case .expandActions, .open, .swiping, .willPerformFirstActionAutomatically:
+                false
+            }
 
             if animated {
                 UIViewPropertyAnimator {


### PR DESCRIPTION
We don't want cell content to be interactable while the swipe actions are visisble. All touches should close the swipe area (and perform the associated action if a button was tapped), nothing else.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
