### PR TITLE
Fix reordering crash introduced in 16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fixed a crash that would occur when a user would reorder / move items between sections.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/ListView/ListView.DataSource.swift
+++ b/ListableUI/Sources/ListView/ListView.DataSource.swift
@@ -185,14 +185,16 @@ internal extension ListView
                 )
             }
             
-            ListStateObserver.perform(self.view.stateObserver.onItemReordered, "Item Reordered", with: self.view) {
-                ListStateObserver.ItemReordered(
-                    actions: $0,
-                    positionInfo: self.view.scrollPositionInfo,
-                    item: item.anyModel,
-                    sections: self.presentationState.sectionModels,
-                    result: result
-                )
+            self.view.updateQueue.add {
+                ListStateObserver.perform(self.view.stateObserver.onItemReordered, "Item Reordered", with: self.view) {
+                    ListStateObserver.ItemReordered(
+                        actions: $0,
+                        positionInfo: self.view.scrollPositionInfo,
+                        item: item.anyModel,
+                        sections: self.presentationState.sectionModels,
+                        result: result
+                    )
+                }
             }
         }
     }

--- a/ListableUI/Sources/ListView/ListView.DataSource.swift
+++ b/ListableUI/Sources/ListView/ListView.DataSource.swift
@@ -185,6 +185,10 @@ internal extension ListView
                 )
             }
             
+            /// We need to place this `ListStateObserver` in the `updateQueue` to ensure that the
+            /// reorder-triggered re-layout of our `CollectionViewLayout` has occured. Without waiting
+            /// for this, any work within the observer that queries the collection view layout may either (a) retrieve
+            /// the wrong item, or (b) crash if items were moved between sections.
             self.view.updateQueue.add {
                 ListStateObserver.perform(self.view.stateObserver.onItemReordered, "Item Reordered", with: self.view) {
                     ListStateObserver.ItemReordered(

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,16 +2,16 @@ PODS:
   - BlueprintUI (5.0.0)
   - BlueprintUICommonControls (5.0.0):
     - BlueprintUI (= 5.0.0)
-  - BlueprintUILists (15.0.1):
+  - BlueprintUILists (16.0.0):
     - BlueprintUI (~> 5.0)
     - ListableUI
-  - BlueprintUILists/Tests (15.0.1):
+  - BlueprintUILists/Tests (16.0.0):
     - BlueprintUI (~> 5.0)
     - BlueprintUICommonControls (~> 5.0)
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
-  - ListableUI (15.0.1)
-  - ListableUI/Tests (15.0.1):
+  - ListableUI (16.0.0)
+  - ListableUI/Tests (16.0.0):
     - EnglishDictionary
     - Snapshot
   - Snapshot (1.0.0.LOCAL)
@@ -46,9 +46,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BlueprintUI: 0e2d2944bca6c0d6d96df711a43bce01154bb7ef
   BlueprintUICommonControls: 8f400ee3ecf2bc58bd21cce29caba9f7c83d22b8
-  BlueprintUILists: 7e0c46a381e146c6c91951fc96146986cf25b860
+  BlueprintUILists: dcc67c0991910216d7f45eec434422e478095e4f
   EnglishDictionary: 2cf40d33cc1b68c4152a1cc69561aaf6e4ba0209
-  ListableUI: 126109e23ff38093884ddffd22dd68cd36dd2cc9
+  ListableUI: 3dc22acdc7b6ff61e70e0e1a23a6dea14ab4fd5b
   Snapshot: 574e65b08c02491a541efbd2619c92cc26514d1c
 
 PODFILE CHECKSUM: 2b979d4f2436d28af7c87b125b646836119b89b7


### PR DESCRIPTION
In https://github.com/square/Listable/pull/560 we introduced a `percentageVisible` property on our list position info to support peek-based page layouts – this is usually fine, but due to event ordering, and namely how it takes an extra runloop for the collection view layout to update  after `collectionView(_ collectionView: UICollectionView, moveItemAt from: IndexPath, to: IndexPath)` is called, we end up in a state where the list's storage is inconsistent with its layout. This means that our call to `ListStateObserver.perform(self.view.stateObserver.onItemReordered, "Item Reordered" ...)` would crash / be wrong until the layout occurred. The fix is to place the `Item Reordered` observer callback at the end of the update queue, so the collection view has time to "settle" internally and become consistent.

[Relevant Slack Thread](https://square.slack.com/archives/CTJ4UNLHF/p1744750475867669)

https://block.atlassian.net/browse/UI-8607

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
