### PR TITLE
Addressing an AutoScrollAction issue when using VerticalLayoutGravity.bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- Fixed an issue with `AutoScrollAction.scrollToItem` that caused the scrolled offset to be reset to the bottom when using `VerticalLayoutGravity.bottom`.
+- Fixed an issue with `AutoScrollAction.OnInsertedItem` and `AutoScrollAction.Pin` that caused the scrolled offset to be reset to the bottom when using `VerticalLayoutGravity.bottom`.
 - Fixed issue with the `didPerform` closures of `AutoScrollAction.OnInsertedItem` and `AutoScrollAction.Pin`, where the visible items were stale after adjusting the offset with no animation. 
 
 ### Added
@@ -15,7 +15,8 @@
 
 ### Internal
 
-- Adding a new demo to showcase mixing `AutoScrollAction.scrollToItem` with `VerticalLayoutGravity.bottom`.
+- Adding new demos to showcase mixing `AutoScrollAction.OnInsertedItem` and `AutoScrollAction.Pin` with `VerticalLayoutGravity.bottom`.
+- Adding a new `AutoScrollAction.Behavior` protocol.
 
 # Past Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixed
 
 - Fixed an issue with `AutoScrollAction.scrollToItem` that caused the scrolled offset to be reset to the bottom when using `VerticalLayoutGravity.bottom`.
-- Fixed an issue with the `didPerform` closure of `AutoScrollAction.OnInsertedItem`, where the visible items were stale after adjusting the offset with no animation. 
+- Fixed issue with the `didPerform` closures of `AutoScrollAction.OnInsertedItem` and `AutoScrollAction.Pin`, where the visible items were stale after adjusting the offset with no animation. 
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Fixed
 
+- Fixed an issue with `AutoScrollAction.scrollToItem` that caused the scrolled offset to be reset to the bottom when using `VerticalLayoutGravity.bottom`.
+- Fixed an issue with the `didPerform` closure of `AutoScrollAction.OnInsertedItem`, where the visible items were stale after adjusting the offset with no animation. 
+
 ### Added
 
 ### Removed
@@ -11,6 +14,8 @@
 ### Misc
 
 ### Internal
+
+- Adding a new demo to showcase mixing `AutoScrollAction.scrollToItem` with `VerticalLayoutGravity.bottom`.
 
 # Past Releases
 

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		2B1B39902A706B3D00D614F1 /* ChatDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1B398F2A706B3D00D614F1 /* ChatDemoViewController.swift */; };
 		2B56913A2846737C00E575BE /* AutoScrollingViewController2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5691392846737C00E575BE /* AutoScrollingViewController2.swift */; };
 		2B8804652490844A003BB351 /* SpacingCustomizationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8804642490844A003BB351 /* SpacingCustomizationViewController.swift */; };
+		2BCF36752DC29E0D00C4D479 /* AutoScrollingViewController3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCF36742DC29E0600C4D479 /* AutoScrollingViewController3.swift */; };
 		397F72040272B0B12CAD9AEE /* Pods_Test_Targets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF78F98F7ED38C2DC8078110 /* Pods_Test_Targets.framework */; };
 		8ECEBF6228B7E4C200ECEC56 /* CenterSnappingTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ECEBF6128B7E4C200ECEC56 /* CenterSnappingTableViewController.swift */; };
 		B223A33A769988911ED5C0E1 /* Pods_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1C03134338F55F7FD12551D /* Pods_Demo.framework */; };
@@ -110,6 +111,7 @@
 		2B1B398F2A706B3D00D614F1 /* ChatDemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatDemoViewController.swift; sourceTree = "<group>"; };
 		2B5691392846737C00E575BE /* AutoScrollingViewController2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoScrollingViewController2.swift; sourceTree = "<group>"; };
 		2B8804642490844A003BB351 /* SpacingCustomizationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacingCustomizationViewController.swift; sourceTree = "<group>"; };
+		2BCF36742DC29E0600C4D479 /* AutoScrollingViewController3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoScrollingViewController3.swift; sourceTree = "<group>"; };
 		8ECEBF6128B7E4C200ECEC56 /* CenterSnappingTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CenterSnappingTableViewController.swift; sourceTree = "<group>"; };
 		A1C03134338F55F7FD12551D /* Pods_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C55FB4CC847A4E4F271441F7 /* Pods-Test Targets.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Test Targets.debug.xcconfig"; path = "Target Support Files/Pods-Test Targets/Pods-Test Targets.debug.xcconfig"; sourceTree = "<group>"; };
@@ -153,10 +155,12 @@
 		0AA4D9CA248064AE00CF95A5 /* Demo Screens */ = {
 			isa = PBXGroup;
 			children = (
+				2BCF36742DC29E0600C4D479 /* AutoScrollingViewController3.swift */,
 				0A49210324E5E11300D17038 /* AccordionViewController.swift */,
 				0AD0CF6628B57759000ECF0C /* SupplementaryTestingViewController.swift */,
 				0A66420A254A317A007F6B2F /* AutoLayoutDemoViewController.swift */,
 				0AA4D9B4248064A300CF95A5 /* AutoScrollingViewController.swift */,
+				2B5691392846737C00E575BE /* AutoScrollingViewController2.swift */,
 				0AA4D9AC248064A300CF95A5 /* BlueprintListDemoViewController.swift */,
 				8ECEBF6128B7E4C200ECEC56 /* CenterSnappingTableViewController.swift */,
 				0AA4D9B2248064A300CF95A5 /* CollectionViewAppearance.swift */,
@@ -189,7 +193,6 @@
 				0AA4D9B5248064A300CF95A5 /* SwipeActionsViewController.swift */,
 				0AA4D9AE248064A300CF95A5 /* WidthCustomizationViewController.swift */,
 				0AC839A425EEAD110055CEF5 /* OnTapItemAnimationViewController.swift */,
-				2B5691392846737C00E575BE /* AutoScrollingViewController2.swift */,
 			);
 			path = "Demo Screens";
 			sourceTree = "<group>";
@@ -484,6 +487,7 @@
 				0A07119324BA798400CDF65D /* ListStateViewController.swift in Sources */,
 				0AA4D9C0248064A300CF95A5 /* InvoicesPaymentScheduleDemoViewController.swift in Sources */,
 				0A66420B254A317A007F6B2F /* AutoLayoutDemoViewController.swift in Sources */,
+				2BCF36752DC29E0D00C4D479 /* AutoScrollingViewController3.swift in Sources */,
 				0AEB96E222FBCC1D00341DFF /* AppDelegate.swift in Sources */,
 				2B1B39902A706B3D00D614F1 /* ChatDemoViewController.swift in Sources */,
 				0A793B5824E4B53500850139 /* ManualSelectionManagementViewController.swift in Sources */,

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -155,12 +155,12 @@
 		0AA4D9CA248064AE00CF95A5 /* Demo Screens */ = {
 			isa = PBXGroup;
 			children = (
-				2BCF36742DC29E0600C4D479 /* AutoScrollingViewController3.swift */,
 				0A49210324E5E11300D17038 /* AccordionViewController.swift */,
 				0AD0CF6628B57759000ECF0C /* SupplementaryTestingViewController.swift */,
 				0A66420A254A317A007F6B2F /* AutoLayoutDemoViewController.swift */,
 				0AA4D9B4248064A300CF95A5 /* AutoScrollingViewController.swift */,
 				2B5691392846737C00E575BE /* AutoScrollingViewController2.swift */,
+				2BCF36742DC29E0600C4D479 /* AutoScrollingViewController3.swift */,
 				0AA4D9AC248064A300CF95A5 /* BlueprintListDemoViewController.swift */,
 				8ECEBF6128B7E4C200ECEC56 /* CenterSnappingTableViewController.swift */,
 				0AA4D9B2248064A300CF95A5 /* CollectionViewAppearance.swift */,

--- a/Demo/Sources/Demos/Demo Screens/AutoScrollingViewController2.swift
+++ b/Demo/Sources/Demos/Demo Screens/AutoScrollingViewController2.swift
@@ -18,6 +18,8 @@ final class AutoScrollingViewController2 : UIViewController
     let list = ListView()
 
     private var items: [Item<BottomPinnedItem>] = []
+    
+    private var animatePinning: Bool = true
 
     override func loadView()
     {
@@ -35,6 +37,7 @@ final class AutoScrollingViewController2 : UIViewController
         self.navigationItem.rightBarButtonItems = [
             UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addItem)),
             UIBarButtonItem(title: "Remove", style: .plain, target: self, action: #selector(removeItem)),
+            UIBarButtonItem(title: "Toggle Animations", style: .plain, target: self, action: #selector(toggleAnimations))
         ]
     }
 
@@ -66,14 +69,14 @@ final class AutoScrollingViewController2 : UIViewController
             list.autoScrollAction = .pin(
                 .lastItem,
                 position: .init(position: .bottom),
-                animated: true,
+                animated: animatePinning,
                 shouldPerform: { info in
                     // Only auto-scroll if we're currently scrolled less than a
                     // screen's-height from the bottom
                     return info.bottomScrollOffset < info.bounds.height - info.safeAreaInsets.top
                 },
                 didPerform: { info in
-                    print("Did scroll: \(info)")
+                    print("Did scroll: \(info.visibleItems.map(\.identifier))")
                 }
             )
 
@@ -83,5 +86,10 @@ final class AutoScrollingViewController2 : UIViewController
                 BottomPinnedItem(text: "Total $10.00")
             }
         }
+    }
+    
+    @objc func toggleAnimations() {
+        animatePinning.toggle()
+        print("pin animations are \(animatePinning ? "on" : "off").")
     }
 }

--- a/Demo/Sources/Demos/Demo Screens/AutoScrollingViewController3.swift
+++ b/Demo/Sources/Demos/Demo Screens/AutoScrollingViewController3.swift
@@ -14,7 +14,7 @@ import BlueprintUI
 import BlueprintUICommonControls
 
 
-final class AutoScrollingViewController3 : UIViewController {
+class AutoScrollingViewController3 : UIViewController {
     
     let list = ListView()
     
@@ -30,7 +30,7 @@ final class AutoScrollingViewController3 : UIViewController {
         UIBarButtonItem(title: "Toggle Animations", style: .plain, target: self, action: #selector(toggleAnimations))
     }()
     
-    private var animateAutoscroll: Bool = false
+    fileprivate var animateAutoscroll: Bool = false
 
     private var items: [Item<BottomPinnedItem>] = Array(0...100).map {
         Item(BottomPinnedItem(text: "Item \($0)"))
@@ -38,7 +38,12 @@ final class AutoScrollingViewController3 : UIViewController {
     
     private var observedItem = Item(BottomPinnedItem(text: "Item 50"))
     
-    private var seekToIdentifier: AnyIdentifier { observedItem.anyIdentifier }
+    fileprivate var seekToIdentifier: AnyIdentifier { observedItem.anyIdentifier }
+    
+    var autoScrollAction: AutoScrollAction {
+        assertionFailure("Override \(#function) in subclasses.")
+        return .pin(.firstItem, position: .init(position: .top))
+    }
 
     override func loadView() {
         self.view = self.list
@@ -57,18 +62,9 @@ final class AutoScrollingViewController3 : UIViewController {
             list.layout = .demoLayout
             list.behavior.verticalLayoutGravity = .bottom
             list.animation = .fast
+            list.autoScrollAction = autoScrollAction
+            
             list += Section("items", items: items)
-
-            list.autoScrollAction = .scrollTo(
-                .item(seekToIdentifier),
-                onInsertOf: seekToIdentifier,
-                position: .init(position: .centered, ifAlreadyVisible: .scrollToPosition),
-                animated: animateAutoscroll,
-                didPerform: { info in
-                    print("Did scroll: \(info.visibleItems.map(\.identifier))")
-                }
-            )
-
             list += Section("itemization") {
                 BottomPinnedItem(text: "Tax $2.00")
                 BottomPinnedItem(text: "Discount $4.00")
@@ -94,5 +90,32 @@ final class AutoScrollingViewController3 : UIViewController {
     @objc func toggleAnimations() {
         animateAutoscroll.toggle()
         print("autoScrollAction animations are \(animateAutoscroll ? "on" : "off").")
+    }
+}
+
+final class ScrollToAutoscrollingViewController: AutoScrollingViewController3 {
+    override var autoScrollAction: AutoScrollAction {
+        .scrollTo(
+            .item(seekToIdentifier),
+            onInsertOf: seekToIdentifier,
+            position: .init(position: .centered, ifAlreadyVisible: .scrollToPosition),
+            animated: animateAutoscroll,
+            didPerform: { info in
+                print("Did scroll: \(info.visibleItems.map(\.identifier))")
+            }
+        )
+    }
+}
+
+final class PinAutoscrollingViewController: AutoScrollingViewController3 {
+    override var autoScrollAction: AutoScrollAction {
+        .pin(
+            .item(seekToIdentifier),
+            position: .init(position: .centered, ifAlreadyVisible: .scrollToPosition),
+            animated: animateAutoscroll,
+            didPerform: { info in
+                print("Did scroll: \(info.visibleItems.map(\.identifier))")
+            }
+        )
     }
 }

--- a/Demo/Sources/Demos/Demo Screens/AutoScrollingViewController3.swift
+++ b/Demo/Sources/Demos/Demo Screens/AutoScrollingViewController3.swift
@@ -1,0 +1,66 @@
+//
+//  AutoScrollingViewController3.swift
+//  Demo
+//
+//  Created by Gil Birman on 4/30/25.
+//  Copyright © 2025 Kyle Van Essen. All rights reserved.
+//
+
+import UIKit
+
+import ListableUI
+import BlueprintUILists
+import BlueprintUI
+import BlueprintUICommonControls
+
+
+final class AutoScrollingViewController3 : UIViewController
+{
+    let list = ListView()
+
+    private let items: [Item<BottomPinnedItem>] = Array(0...100).map {
+        Item(BottomPinnedItem(text: "Item \($0)"))
+    }
+
+    override func loadView() {
+        self.view = self.list
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        updateItems()
+    }
+
+    private func updateItems() {
+        
+        self.list.configure { list in
+            list.appearance = .demoAppearance
+            list.layout = .demoLayout
+
+            // THIS WORKS ONLY IF YOU CHANGE THIS TO .top:
+            list.behavior.verticalLayoutGravity = .bottom
+
+            list.animation = .fast
+            
+            list += Section("items", items: self.items)
+
+            let seekToIdentifier = items[Int(items.count / 2)].anyIdentifier
+            list.autoScrollAction = .scrollTo(
+                .item(seekToIdentifier),
+                onInsertOf: seekToIdentifier,
+                position: .init(position: .centered, ifAlreadyVisible: .scrollToPosition),
+                animated: false,
+                didPerform: { info in
+                    print("Did scroll: \(info)")
+                }
+            )
+
+            list += Section("itemization") {
+                BottomPinnedItem(text: "Tax $2.00")
+                BottomPinnedItem(text: "Discount $4.00")
+                BottomPinnedItem(text: "Total $10.00")
+            }
+        }
+    }
+}

--- a/Demo/Sources/Demos/Demo Screens/AutoScrollingViewController3.swift
+++ b/Demo/Sources/Demos/Demo Screens/AutoScrollingViewController3.swift
@@ -14,8 +14,8 @@ import BlueprintUI
 import BlueprintUICommonControls
 
 
-final class AutoScrollingViewController3 : UIViewController
-{
+final class AutoScrollingViewController3 : UIViewController {
+    
     let list = ListView()
     
     lazy var insertButton: UIBarButtonItem = {
@@ -48,21 +48,16 @@ final class AutoScrollingViewController3 : UIViewController
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         updateItems()
     }
 
     private func updateItems() {
-        
-        self.list.configure { list in
+        list.configure { list in
             list.appearance = .demoAppearance
             list.layout = .demoLayout
-
             list.behavior.verticalLayoutGravity = .bottom
-
             list.animation = .fast
-            
-            list += Section("items", items: self.items)
+            list += Section("items", items: items)
 
             list.autoScrollAction = .scrollTo(
                 .item(seekToIdentifier),

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -66,6 +66,14 @@ public final class DemosRootViewController : ListViewController
                 )
 
                 Item(
+                    DemoItem(text: "Auto Scrolling3 (Scroll to middle)"),
+                    selectionStyle: .selectable(),
+                    onSelect : { _ in
+                        self?.push(AutoScrollingViewController3())
+                    }
+                )
+
+                Item(
                     DemoItem(text: "List State & State Reader"),
                     selectionStyle: .selectable(),
                     onSelect: { _ in

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -66,10 +66,18 @@ public final class DemosRootViewController : ListViewController
                 )
 
                 Item(
-                    DemoItem(text: "Auto Scrolling3 (Scroll to middle)"),
+                    DemoItem(text: "Auto Scrolling3 (Center Pin: scrollTo + bottom gravity)"),
                     selectionStyle: .selectable(),
                     onSelect : { _ in
-                        self?.push(AutoScrollingViewController3())
+                        self?.push(ScrollToAutoscrollingViewController())
+                    }
+                )
+
+                Item(
+                    DemoItem(text: "Auto Scrolling3 (Center Pin: pin + bottom gravity)"),
+                    selectionStyle: .selectable(),
+                    onSelect : { _ in
+                        self?.push(PinAutoscrollingViewController())
                     }
                 )
 

--- a/ListableUI/Sources/AutoScrollAction.swift
+++ b/ListableUI/Sources/AutoScrollAction.swift
@@ -172,7 +172,6 @@ extension AutoScrollAction
         
         /// Called when the list performs the insertion.
         var didPerform : (ListScrollPositionInfo) -> () { get set }
-        
     }
     
     /// Values used to configure the `scrollToItem(onInsertOf:)` action.

--- a/ListableUI/Sources/AutoScrollAction.swift
+++ b/ListableUI/Sources/AutoScrollAction.swift
@@ -150,9 +150,33 @@ extension AutoScrollAction
         }
     }
     
+    /// This protocol allows `ListView` to treat the `OnInsertedItem` and `Pin` behaviors
+    /// in a similar fashion.
+    public protocol Behavior {
+        
+        /// The item in the list to scroll to.
+        var destination : ScrollDestination { get set }
+        
+        /// The desired scroll position.
+        var position : ScrollPosition { get set }
+        
+        /// If the change should be animated.
+        ///
+        /// ### Note
+        /// The action will only be animated if it is animated, **and** the list update itself is
+        /// animated. Otherwise, no animation occurs.
+        var animated : Bool { get set }
+        
+        /// An additional check you may provide to approve or reject the scroll action.
+        var shouldPerform : (ListScrollPositionInfo) -> Bool { get set }
+        
+        /// Called when the list performs the insertion.
+        var didPerform : (ListScrollPositionInfo) -> () { get set }
+        
+    }
     
     /// Values used to configure the `scrollToItem(onInsertOf:)` action.
-    public struct OnInsertedItem
+    public struct OnInsertedItem: AutoScrollAction.Behavior
     {
         /// The item in the list to scroll to when the `insertedIdentifier` is inserted.
         public var destination : ScrollDestination
@@ -160,43 +184,26 @@ extension AutoScrollAction
         /// The identifier of the item for which the `AutoScrollAction` should be performed.
         public var insertedIdentifier : AnyIdentifier
         
-        /// The desired scroll position,
         public var position : ScrollPosition
         
-        /// If the change should be animated.
-        ///
-        /// ### Note
-        /// The action will only be animated if it is animated, **and** the list update itself is
-        /// animated. Otherwise, no animation occurs.
         public var animated : Bool
         
-        /// An additional check you may provide to approve or reject the scroll action.
         public var shouldPerform : (ListScrollPositionInfo) -> Bool
         
-        /// Called when the list performs the insertion.
         public var didPerform : (ListScrollPositionInfo) -> ()
     }
 
     /// Values used to configure the `pin(to:)` action.
-    public struct Pin
+    public struct Pin: AutoScrollAction.Behavior
     {
-        /// The item in the list to scroll to.
         public var destination : ScrollDestination
 
-        /// The desired scroll position,
         public var position : ScrollPosition
         
-        /// If the change should be animated.
-        ///
-        /// ### Note
-        /// The action will only be animated if it is animated, **and** the list update itself is
-        /// animated. Otherwise, no animation occurs.
         public var animated : Bool
         
-        /// An additional check you may provide to approve or reject the scroll action.
         public var shouldPerform : (ListScrollPositionInfo) -> Bool
         
-        /// Called when the list performs the insertion.
         public var didPerform : (ListScrollPositionInfo) -> ()
     }
 }

--- a/ListableUI/Sources/AutoScrollAction.swift
+++ b/ListableUI/Sources/AutoScrollAction.swift
@@ -150,9 +150,9 @@ extension AutoScrollAction
         }
     }
     
-    /// This protocol allows `ListView` to treat the `OnInsertedItem` and `Pin` behaviors
+    /// This protocol allows `ListView` to treat the `OnInsertedItem` and `Pin` configurations
     /// in a similar fashion.
-    public protocol Behavior {
+    public protocol Configuration {
         
         /// The item in the list to scroll to.
         var destination : ScrollDestination { get set }
@@ -175,7 +175,7 @@ extension AutoScrollAction
     }
     
     /// Values used to configure the `scrollToItem(onInsertOf:)` action.
-    public struct OnInsertedItem: AutoScrollAction.Behavior
+    public struct OnInsertedItem: AutoScrollAction.Configuration
     {
         /// The item in the list to scroll to when the `insertedIdentifier` is inserted.
         public var destination : ScrollDestination
@@ -193,7 +193,7 @@ extension AutoScrollAction
     }
 
     /// Values used to configure the `pin(to:)` action.
-    public struct Pin: AutoScrollAction.Behavior
+    public struct Pin: AutoScrollAction.Configuration
     {
         public var destination : ScrollDestination
 

--- a/ListableUI/Sources/ListView/ListView.CollectionViewChanges.swift
+++ b/ListableUI/Sources/ListView/ListView.CollectionViewChanges.swift
@@ -86,5 +86,12 @@ internal extension ListView
                 self.movedItems += $0.itemChanges.moved
             }
         }
+        
+        private init() {}
+        
+        /// Returns an instance of `CollectionViewChanges` containing no changes.
+        static var empty: CollectionViewChanges {
+            CollectionViewChanges()
+        }
     }
 }

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1303,7 +1303,7 @@ public final class ListView : UIView
                         /// asynchronously update the underlying `contentSize` as part of the initial layout,
                         /// moments after this method is executed. The list's `contentSize` is overridden to
                         /// keep the offset anchored to the bottom when using `VerticalLayoutGravity.bottom`.
-                        collectionView.performBatchUpdates(nil)
+                        performEmptyBatchUpdates()
                     }
                     
                     guard self.scrollTo(item: destination, position: info.position, animated: animated) else { return }
@@ -1316,7 +1316,7 @@ public final class ListView : UIView
                         /// `prepare()` function will synchronously execute before calling `didPerform`. Otherwise,
                         /// the list's `visibleContent` and the resulting `scrollPositionInfo.visibleItems` will
                         /// be stale.
-                        collectionView.performBatchUpdates(nil)
+                        performEmptyBatchUpdates()
                         info.didPerform(scrollPositionInfo)
                     }
                 }
@@ -1407,6 +1407,16 @@ public final class ListView : UIView
         }
 
         return true
+    }
+    
+    /// This is similar to calling `collectionView.performBatchUpdates(nil)`, but
+    /// it also includes workarounds for first responder bugs on iOS 16.4 and 17.0.
+    private func performEmptyBatchUpdates() {
+        collectionView.performBatchUpdates(
+            {},
+            changes: CollectionViewChanges.empty,
+            completion: { _ in }
+        )
     }
     
     private func performBatchUpdates(

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1291,7 +1291,7 @@ public final class ListView : UIView
                 if let destination = info.destination.destination(with: self.content) {
                     
                     if behavior.verticalLayoutGravity == .bottom {
-                        /// Perform a layout to adjust the `contentSize` of the collection view before
+                        /// Perform an update to adjust the `contentSize` of the collection view before
                         /// scrolling. This avoids an issue where:
                         ///   - the list is first appearing with `VerticalLayoutGravity.bottom` and
                         ///     `AutoScrollAction` behaviors
@@ -1303,7 +1303,7 @@ public final class ListView : UIView
                         /// asynchronously update the underlying `contentSize` as part of the initial layout,
                         /// moments after this method is executed. The list's `contentSize` is overridden to
                         /// keep the offset anchored to the bottom when using `VerticalLayoutGravity.bottom`.
-                        collectionView.layoutIfNeeded()
+                        collectionView.performBatchUpdates(nil)
                     }
                     
                     guard self.scrollTo(item: destination, position: info.position, animated: animated) else { return }
@@ -1312,11 +1312,11 @@ public final class ListView : UIView
                             info.didPerform(state.positionInfo)
                         }
                     } else {
-                        /// Perform a layout after an animationless scroll so that `CollectionViewLayout`'s
+                        /// Perform an update after an animationless scroll so that `CollectionViewLayout`'s
                         /// `prepare()` function will synchronously execute before calling `didPerform`. Otherwise,
                         /// the list's `visibleContent` and the resulting `scrollPositionInfo.visibleItems` will
                         /// be stale.
-                        collectionView.layoutIfNeeded()
+                        collectionView.performBatchUpdates(nil)
                         info.didPerform(scrollPositionInfo)
                     }
                 }

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1286,8 +1286,8 @@ public final class ListView : UIView
                     if behavior.verticalLayoutGravity == .bottom {
                         /// Perform a layout to adjust the `contentSize` of the collection view before
                         /// scrolling. This avoids an issue where:
-                        ///   - the list is first appearing with a `bottom` `VerticalLayoutGravity` and a
-                        ///     `scrollToItem(onInsertOf:)` `AutoScrollAction`.
+                        ///   - the list is first appearing with `VerticalLayoutGravity.bottom` and
+                        ///     `AutoScrollAction.scrollToItem(onInsertOf:)` behaviors
                         ///   - the initial set of items in the list trigger the `scrollToItem(onInsertOf:)`
                         ///   - the resulting scroll position isn't at the bottom of the list
                         ///
@@ -1295,7 +1295,7 @@ public final class ListView : UIView
                         /// to the bottom, discarding this scroll update. This is because the system will
                         /// asynchronously update the underlying `contentSize` as part of the initial layout,
                         /// moments after this method is executed. The list's `contentSize` is overridden to
-                        /// keep the offset anchored to the bottom when using `bottom` `VerticalLayoutGravity`.
+                        /// keep the offset anchored to the bottom when using `VerticalLayoutGravity.bottom`.
                         collectionView.layoutIfNeeded()
                     }
                     

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1282,7 +1282,7 @@ public final class ListView : UIView
             autoScroll(with: pin)
         }
         
-        func autoScroll(with info: AutoScrollAction.Behavior) {
+        func autoScroll(with info: AutoScrollAction.Configuration) {
             if info.shouldPerform(self.scrollPositionInfo) {
                 
                 /// Only animate the scroll if both the update **and** the scroll action are animated.

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1327,6 +1327,11 @@ public final class ListView : UIView
                             pin.didPerform(self.scrollPositionInfo)
                         }
                     } else {
+                        /// Perform a layout after an animationless scroll so that `CollectionViewLayout`'s
+                        /// `prepare()` function will synchronously execute before calling `didPerform`. Otherwise,
+                        /// the list's `visibleContent` and the resulting `scrollPositionInfo.visibleItems` will
+                        /// be stale.
+                        collectionView.layoutIfNeeded()
                         pin.didPerform(self.scrollPositionInfo)
                     }
                 }

--- a/ListableUI/Tests/ListView/ListViewTests.swift
+++ b/ListableUI/Tests/ListView/ListViewTests.swift
@@ -616,9 +616,7 @@ class ListViewTests: XCTestCase
             var didPerform : [ListScrollPositionInfo] = []
             
             var content = ListProperties.default { list in
-                
                 list.animatesChanges = false
-                
                 list.sections = (1...50).map { sectionID in
                     Section(sectionID) {
                         for itemNumber in 1...20 {
@@ -628,7 +626,6 @@ class ListViewTests: XCTestCase
                 }
                 
                 let ID = TestContent.identifier(with: "A")
-                
                 list.autoScrollAction = .scrollTo(
                     .item(ID),
                     onInsertOf: ID,
@@ -694,7 +691,6 @@ class ListViewTests: XCTestCase
             var didPerform : [ListScrollPositionInfo] = []
             
             var content = ListProperties.default { list in
-                
                 list.animatesChanges = false
                 list.behavior.verticalLayoutGravity = .bottom
                 list.sections = (1...50).map { sectionID in
@@ -706,7 +702,6 @@ class ListViewTests: XCTestCase
                 }
                 
                 let ID = TestContent.identifier(with: "A")
-                
                 list.autoScrollAction = .scrollTo(
                     .item(ID),
                     onInsertOf: ID,
@@ -782,7 +777,6 @@ class ListViewTests: XCTestCase
             var didPerform : [ListScrollPositionInfo] = []
             
             var content = ListProperties.default { list in
-                
                 list.sections = (1...50).map { sectionID in
                     Section(sectionID) {
                         for itemID in 1...20 {
@@ -792,7 +786,6 @@ class ListViewTests: XCTestCase
                 }
                 
                 let ID = TestContent.identifier(with: "A")
-                
                 list.autoScrollAction = .pin(
                     .item(ID),
                     position: .init(position: .bottom),
@@ -806,15 +799,11 @@ class ListViewTests: XCTestCase
 
             show(vc: vc) { vc in
                 vc.list.configure(with: content)
-
                 waitFor { vc.list.updateQueue.isEmpty }
-                
                 XCTAssertEqual(didPerform.count, 0)
                 
                 vc.list.configure(with: content)
-
                 waitFor { vc.list.updateQueue.isEmpty }
-                
                 XCTAssertEqual(didPerform.count, 0)
                 
                 content.content += Section("new") {
@@ -822,10 +811,10 @@ class ListViewTests: XCTestCase
                 }
                 
                 vc.list.configure(with: content)
-                
                 waitFor { vc.list.updateQueue.isEmpty }
-                
                 XCTAssertEqual(didPerform.count, 1)
+                
+                // TODO: Assert that the visible items are correct when using `pin(...)`.
             }
         }
     }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,16 +2,16 @@ PODS:
   - BlueprintUI (5.0.0)
   - BlueprintUICommonControls (5.0.0):
     - BlueprintUI (= 5.0.0)
-  - BlueprintUILists (16.0.0):
+  - BlueprintUILists (16.0.1):
     - BlueprintUI (~> 5.0)
     - ListableUI
-  - BlueprintUILists/Tests (16.0.0):
+  - BlueprintUILists/Tests (16.0.1):
     - BlueprintUI (~> 5.0)
     - BlueprintUICommonControls (~> 5.0)
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
-  - ListableUI (16.0.0)
-  - ListableUI/Tests (16.0.0):
+  - ListableUI (16.0.1)
+  - ListableUI/Tests (16.0.1):
     - EnglishDictionary
     - Snapshot
   - Snapshot (1.0.0.LOCAL)
@@ -46,9 +46,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BlueprintUI: 0e2d2944bca6c0d6d96df711a43bce01154bb7ef
   BlueprintUICommonControls: 8f400ee3ecf2bc58bd21cce29caba9f7c83d22b8
-  BlueprintUILists: dcc67c0991910216d7f45eec434422e478095e4f
+  BlueprintUILists: 980331331e2d9716ea60f72a4c3afa6ffd5ebb14
   EnglishDictionary: 2cf40d33cc1b68c4152a1cc69561aaf6e4ba0209
-  ListableUI: 3dc22acdc7b6ff61e70e0e1a23a6dea14ab4fd5b
+  ListableUI: 15ba0d519febed55e3a322bbf217bef7336d5dd5
   Snapshot: 574e65b08c02491a541efbd2619c92cc26514d1c
 
 PODFILE CHECKSUM: 2b979d4f2436d28af7c87b125b646836119b89b7


### PR DESCRIPTION
- Adjusting the underlying CollectionView's `contentSize` before auto-scrolling. This will scroll after  the  `contentSize` logic  within CollectionView ([here](https://github.com/square/Listable/blob/main/ListableUI/Sources/ListView/ListView.swift#L1711)) has adjusted the offset.
- Ensuring the items provided to the `didPerform` closure are synced with the visible items after scrolling.

### Checklist

Please do the following before merging:

- [x] Unit tests.
- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
