### PR TITLE
Ensuring the visible items are accurate with AutoScrollAction.Pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixed
 
 - Fixed an issue with `AutoScrollAction.scrollToItem` that caused the scrolled offset to be reset to the bottom when using `VerticalLayoutGravity.bottom`.
-- Fixed an issue with the `didPerform` closure of `AutoScrollAction.OnInsertedItem`, where the visible items were stale after adjusting the offset with no animation. 
+- Fixed issue with the `didPerform` closures of `AutoScrollAction.OnInsertedItem` and `AutoScrollAction.Pin`, where the visible items were stale after adjusting the offset with no animation. 
 
 ### Added
 

--- a/Demo/Sources/Demos/Demo Screens/AutoScrollingViewController2.swift
+++ b/Demo/Sources/Demos/Demo Screens/AutoScrollingViewController2.swift
@@ -18,6 +18,8 @@ final class AutoScrollingViewController2 : UIViewController
     let list = ListView()
 
     private var items: [Item<BottomPinnedItem>] = []
+    
+    private var animatePinning: Bool = true
 
     override func loadView()
     {
@@ -35,6 +37,7 @@ final class AutoScrollingViewController2 : UIViewController
         self.navigationItem.rightBarButtonItems = [
             UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addItem)),
             UIBarButtonItem(title: "Remove", style: .plain, target: self, action: #selector(removeItem)),
+            UIBarButtonItem(title: "Toggle Animations", style: .plain, target: self, action: #selector(toggleAnimations))
         ]
     }
 
@@ -66,14 +69,14 @@ final class AutoScrollingViewController2 : UIViewController
             list.autoScrollAction = .pin(
                 .lastItem,
                 position: .init(position: .bottom),
-                animated: true,
+                animated: animatePinning,
                 shouldPerform: { info in
                     // Only auto-scroll if we're currently scrolled less than a
                     // screen's-height from the bottom
                     return info.bottomScrollOffset < info.bounds.height - info.safeAreaInsets.top
                 },
                 didPerform: { info in
-                    print("Did scroll: \(info)")
+                    print("Did scroll: \(info.visibleItems.map(\.identifier))")
                 }
             )
 
@@ -83,5 +86,10 @@ final class AutoScrollingViewController2 : UIViewController
                 BottomPinnedItem(text: "Total $10.00")
             }
         }
+    }
+    
+    @objc func toggleAnimations() {
+        animatePinning.toggle()
+        print("pin animations are \(animatePinning ? "on" : "off").")
     }
 }

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1327,6 +1327,11 @@ public final class ListView : UIView
                             pin.didPerform(self.scrollPositionInfo)
                         }
                     } else {
+                        /// Perform a layout after an animationless scroll so that `CollectionViewLayout`'s
+                        /// `prepare()` function will synchronously execute before calling `didPerform`. Otherwise,
+                        /// the list's `visibleContent` and the resulting `scrollPositionInfo.visibleItems` will
+                        /// be stale.
+                        collectionView.layoutIfNeeded()
                         pin.didPerform(self.scrollPositionInfo)
                     }
                 }


### PR DESCRIPTION
This builds on the changes in PR #572, to avoid an issue where the visible items are stale when supplied to the `didPerform` closure of `AutoScrollAction.Pin`.

### Checklist

Please do the following before merging:

- [ ] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
