### PR TITLE
Fix crash when using Headings rotor and we reach start of headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fixed a crash that occurred when, while the cursor is on the first heading, we are on the Headings VoiceOver rotor and swipe up with one finger.
+
 ### Added
 
 - Added support for `onDisplay` and `onEndDisplay` callbacks for `HeaderFooters`.

--- a/Development/Sources/Demos/Demo Screens/ItemizationEditorViewController.swift
+++ b/Development/Sources/Demos/Demo Screens/ItemizationEditorViewController.swift
@@ -181,6 +181,7 @@ struct Header : BlueprintHeaderFooterContent, Equatable
     var elementRepresentation : Element {
         return Inset(insets: UIEdgeInsets(top: 0.0, left: 0.0, bottom: 10.0, right: 0.0), wrapping: Label(text: self.title) { label in
             label.font = .systemFont(ofSize: 30.0, weight: .bold)
+            label.accessibilityTraits = [.header]
         })
     }
 }

--- a/ListableUI/Sources/Layout/ListLayout/ListLayoutContent.swift
+++ b/ListableUI/Sources/Layout/ListLayout/ListLayoutContent.swift
@@ -96,8 +96,12 @@ public final class ListLayoutContent
     func supplementaryLayoutAttributes(of kind : String, at indexPath : IndexPath) -> UICollectionViewLayoutAttributes?
     {
         let section = self.sections[indexPath.section]
-        
-        switch SupplementaryKind(rawValue: kind)! {
+
+        guard let typedKind = SupplementaryKind(rawValue: kind) else {
+            return nil
+        }
+
+        switch typedKind {
         case .listContainerHeader: return self.containerHeader.layoutAttributes(with: indexPath)
         case .listHeader: return self.header.layoutAttributes(with: indexPath)
         case .listFooter: return self.footer.layoutAttributes(with: indexPath)


### PR DESCRIPTION
Fixed a crash that occurred when, while the cursor is on the first heading, we are on the Headings VoiceOver rotor and swipe up with one finger.

## Demo

### Before

https://github.com/user-attachments/assets/bd252b04-c859-4da8-8c0a-492ecaa90416

### After

https://github.com/user-attachments/assets/0cb4d2d9-3db6-4ab6-ba64-9733439f57c3

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
