### PR TITLE
Bottom gravity and autoscroll improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Internal
 
+- Improving how `AutoScrollAction` and `VerticalLayoutGravity.bottom` work together by temporarily ignoring the bottom gravity logic while autoscrolling.
+
 # Past Releases
 
 # [16.0.2] - 2025-05-09

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,16 +2,16 @@ PODS:
   - BlueprintUI (5.0.0)
   - BlueprintUICommonControls (5.0.0):
     - BlueprintUI (= 5.0.0)
-  - BlueprintUILists (16.0.1):
+  - BlueprintUILists (16.0.2):
     - BlueprintUI (~> 5.0)
     - ListableUI
-  - BlueprintUILists/Tests (16.0.1):
+  - BlueprintUILists/Tests (16.0.2):
     - BlueprintUI (~> 5.0)
     - BlueprintUICommonControls (~> 5.0)
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
-  - ListableUI (16.0.1)
-  - ListableUI/Tests (16.0.1):
+  - ListableUI (16.0.2)
+  - ListableUI/Tests (16.0.2):
     - EnglishDictionary
     - Snapshot
   - Snapshot (1.0.0.LOCAL)
@@ -46,9 +46,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BlueprintUI: 0e2d2944bca6c0d6d96df711a43bce01154bb7ef
   BlueprintUICommonControls: 8f400ee3ecf2bc58bd21cce29caba9f7c83d22b8
-  BlueprintUILists: 980331331e2d9716ea60f72a4c3afa6ffd5ebb14
+  BlueprintUILists: ca81f1827331de9bae1df63eae839c266ec724fe
   EnglishDictionary: 2cf40d33cc1b68c4152a1cc69561aaf6e4ba0209
-  ListableUI: 15ba0d519febed55e3a322bbf217bef7336d5dd5
+  ListableUI: 44ab47ee09e1e054c345811c084d439386bee3a6
   Snapshot: 574e65b08c02491a541efbd2619c92cc26514d1c
 
 PODFILE CHECKSUM: 2b979d4f2436d28af7c87b125b646836119b89b7


### PR DESCRIPTION
When AutoScrollAction is engaged, these changes will temporarily ignore the bottom gravity overrides while scrolling to the desired item. This is a lighter alternative to the previous implementation, which asked the collection view to lay out its items before scrolling.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
