### PR TITLE
Update the first responder resignation workaround to be enabled by default and cap at < iOS 19 [UI-8849]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Misc
 
+- The `IOS16_4_First_Responder_Bug_CollectionView` workaround has been capped to OS versions _less_ than iOS 19.0 until the fix has been verified as required and functioning.
+- The interpetation of the `Listable.EnableIOS164FirstResponderWorkaround` user defaults flag now defaults to `true` if no value has been set.
+
 ### Internal
 
 # Past Releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Misc
 
 - The `IOS16_4_First_Responder_Bug_CollectionView` workaround has been capped to OS versions _less_ than iOS 19.0 until the fix has been verified as required and functioning.
-- The interpetation of the `Listable.EnableIOS164FirstResponderWorkaround` user defaults flag now defaults to `true` if no value has been set.
+- The interpretation of the `Listable.EnableIOS164FirstResponderWorkaround` user defaults flag now defaults to `true` if no value has been set.
 
 ### Internal
 

--- a/Demo/Sources/AppDelegate.swift
+++ b/Demo/Sources/AppDelegate.swift
@@ -20,9 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate
         window.rootViewController = DemoNavigationController()
         
         self.window = window
-        
-        UserDefaults.standard.set(true, forKey: "Listable.EnableIOS164FirstResponderWorkaround")
-        
+
         window.makeKeyAndVisible()
         
         return true

--- a/Demo/Sources/Demos/Demo Screens/SystemFlowLayoutViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/SystemFlowLayoutViewController.swift
@@ -119,7 +119,11 @@ extension SystemFlowLayoutViewController : UICollectionViewDataSource, UICollect
                 /// Note that even throwing this in a `DispathQueue.main.async`
                 /// doesn't seem to resolve the issue.
                 collectionView?.performBatchUpdates({})
-                
+
+                // Update 06/04/2025:
+                // On iOS 17+ _two_ `performBatchUpdates` calls are required to
+                // trigger the first responder resignation issue.
+                collectionView?.performBatchUpdates({})
             }
             
             return header

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,16 +2,16 @@ PODS:
   - BlueprintUI (5.0.0)
   - BlueprintUICommonControls (5.0.0):
     - BlueprintUI (= 5.0.0)
-  - BlueprintUILists (16.0.2):
+  - BlueprintUILists (16.0.3):
     - BlueprintUI (~> 5.0)
     - ListableUI
-  - BlueprintUILists/Tests (16.0.2):
+  - BlueprintUILists/Tests (16.0.3):
     - BlueprintUI (~> 5.0)
     - BlueprintUICommonControls (~> 5.0)
     - ListableUI
   - EnglishDictionary (1.0.0.LOCAL)
-  - ListableUI (16.0.2)
-  - ListableUI/Tests (16.0.2):
+  - ListableUI (16.0.3)
+  - ListableUI/Tests (16.0.3):
     - EnglishDictionary
     - Snapshot
   - Snapshot (1.0.0.LOCAL)
@@ -46,9 +46,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   BlueprintUI: 0e2d2944bca6c0d6d96df711a43bce01154bb7ef
   BlueprintUICommonControls: 8f400ee3ecf2bc58bd21cce29caba9f7c83d22b8
-  BlueprintUILists: ca81f1827331de9bae1df63eae839c266ec724fe
+  BlueprintUILists: 61204e3416803e567cb6204f50c011dc096df23b
   EnglishDictionary: 2cf40d33cc1b68c4152a1cc69561aaf6e4ba0209
-  ListableUI: 44ab47ee09e1e054c345811c084d439386bee3a6
+  ListableUI: d2eaa558612c2901b859515cbce789b4f9580a7b
   Snapshot: 574e65b08c02491a541efbd2619c92cc26514d1c
 
 PODFILE CHECKSUM: 2b979d4f2436d28af7c87b125b646836119b89b7


### PR DESCRIPTION
This makes a few changes related to the first responder resignation workaround that exists for collection views.

- If the `Listable.EnableIOS164FirstResponderWorkaround` user defaults flag is not set, it will now default to `true`.
- We cap the workaround to OS versions less than iOS 19.0 until the fix has been verified as required and functioning in the betas that will come out next week.
- Updated the SystemFlowLayout demo to include the updated issue repro steps for iOS 17+

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
