### PR TITLE
Update for Blueprint 6.0.0

### DIFF
--- a/BlueprintUILists/Sources/List.swift
+++ b/BlueprintUILists/Sources/List.swift
@@ -190,28 +190,8 @@ extension List {
                 case .fillParent:
                     if let max = constraint.width.constrainedValue {
                         return max
-                    } else if case .caffeinated = layoutMode {
-                        return .infinity
                     } else {
-                        fatalError(
-                            """
-                            `List` is being used with the `.fillParent` measurement option, which takes \
-                            up the full width it is afforded by its parent element. However, \
-                            the parent element provided the `List` an unconstrained width, which is meaningless.
-                            
-                            How do you fix this?
-                            --------------------
-                            1) This usually means that your `List` itself has been \
-                            placed in a `ScrollView` or other element which intentionally provides an \
-                            unconstrained measurement to its content. If your `List` is in a `ScrollView`, \
-                            remove the outer scroll view – `List` manages its own scrolling. Two `ScrollViews` \
-                            that are nested within each other is generally meaningless unless they scroll \
-                            in different directions (eg, horizontal vs vertical).
-                            
-                            2) If your `List` is not in a `ScrollView`, ensure that the element
-                            measuring it is providing a constrained `SizeConstraint`.
-                            """
-                        )
+                        return .infinity
                     }
                 case .natural:
                     return size.naturalWidth ?? size.contentSize.width
@@ -223,31 +203,11 @@ extension List {
                 case .fillParent:
                     if let max = constraint.height.constrainedValue {
                         return max
-                    } else if case .caffeinated = layoutMode {
-                        return .infinity
                     } else {
-                        fatalError(
-                            """
-                            `List` is being used with the `.fillParent` measurement option, which takes \
-                            up the full height it is afforded by its parent element. However, \
-                            the parent element provided the `List` an unconstrained height, which is meaningless.
-                            
-                            How do you fix this?
-                            --------------------
-                            1) This usually means that your `List` itself has been \
-                            placed in a `ScrollView` or other element which intentionally provides an \
-                            unconstrained measurement to its content. If your `List` is in a `ScrollView`, \
-                            remove the outer scroll view – `List` manages its own scrolling. Two `ScrollViews` \
-                            that are nested within each other is generally meaningless unless they scroll \
-                            in different directions (eg, horizontal vs vertical).
-                            
-                            2) If your `List` is not in a `ScrollView`, ensure that the element
-                            measuring it is providing a constrained `SizeConstraint`.
-                            """
-                        )
+                        return .infinity
                     }
                 case .natural:
-                    if case .caffeinated = layoutMode, let maxHeight = constraint.height.constrainedValue {
+                    if let maxHeight = constraint.height.constrainedValue {
                         return min(size.contentSize.height, maxHeight)
                     }
                     return size.contentSize.height

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Blueprint dependency updated to 6.0.
+
 ### Misc
 
 ### Internal

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/square/Blueprint",
       "state" : {
-        "revision" : "976cdea520ce0f8404124b7e4780c46dc2d98212",
-        "version" : "5.2.0"
+        "revision" : "6e4698ba60752155fc62f39c1fea74cd1d3f18cc",
+        "version" : "6.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/square/Blueprint", from: "5.0.0"),
+        .package(url: "https://github.com/square/Blueprint", from: "6.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
- Removed obsolete layout mode switching
- Updated the dependency to 6.0

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
