### PR TITLE
Reset scroll position if list identifier changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Changed
 
+- Changing a List's `identifier` now automatically resets the scroll position.
+
 ### Misc
 
 - The `IOS16_4_First_Responder_Bug_CollectionView` workaround is longer capped to iOS versions less than 19.0. It was verified as required in the iOS 19 beta.

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		2B8804652490844A003BB351 /* SpacingCustomizationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8804642490844A003BB351 /* SpacingCustomizationViewController.swift */; };
 		2BCF36752DC29E0D00C4D479 /* AutoScrollingViewController3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCF36742DC29E0600C4D479 /* AutoScrollingViewController3.swift */; };
 		397F72040272B0B12CAD9AEE /* Pods_Test_Targets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF78F98F7ED38C2DC8078110 /* Pods_Test_Targets.framework */; };
+		635CB02B2E1584060032AB25 /* IdentifierChangedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635CB02A2E1584060032AB25 /* IdentifierChangedViewController.swift */; };
 		8ECEBF6228B7E4C200ECEC56 /* CenterSnappingTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ECEBF6128B7E4C200ECEC56 /* CenterSnappingTableViewController.swift */; };
 		B223A33A769988911ED5C0E1 /* Pods_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1C03134338F55F7FD12551D /* Pods_Demo.framework */; };
 		CE03D84F2D88584E009F922B /* PeekingPagedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE03D84E2D88584E009F922B /* PeekingPagedViewController.swift */; };
@@ -113,6 +114,7 @@
 		2B5691392846737C00E575BE /* AutoScrollingViewController2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoScrollingViewController2.swift; sourceTree = "<group>"; };
 		2B8804642490844A003BB351 /* SpacingCustomizationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacingCustomizationViewController.swift; sourceTree = "<group>"; };
 		2BCF36742DC29E0600C4D479 /* AutoScrollingViewController3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoScrollingViewController3.swift; sourceTree = "<group>"; };
+		635CB02A2E1584060032AB25 /* IdentifierChangedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierChangedViewController.swift; sourceTree = "<group>"; };
 		8ECEBF6128B7E4C200ECEC56 /* CenterSnappingTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CenterSnappingTableViewController.swift; sourceTree = "<group>"; };
 		A1C03134338F55F7FD12551D /* Pods_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C55FB4CC847A4E4F271441F7 /* Pods-Test Targets.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Test Targets.debug.xcconfig"; path = "Target Support Files/Pods-Test Targets/Pods-Test Targets.debug.xcconfig"; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 				0AA4D9B5248064A300CF95A5 /* SwipeActionsViewController.swift */,
 				0AA4D9AE248064A300CF95A5 /* WidthCustomizationViewController.swift */,
 				0AC839A425EEAD110055CEF5 /* OnTapItemAnimationViewController.swift */,
+				635CB02A2E1584060032AB25 /* IdentifierChangedViewController.swift */,
 			);
 			path = "Demo Screens";
 			sourceTree = "<group>";
@@ -481,6 +484,7 @@
 				0AD0CF6728B57759000ECF0C /* SupplementaryTestingViewController.swift in Sources */,
 				0A57BA2D274FFCE000A118BD /* FlowLayoutViewController.swift in Sources */,
 				0AA4D9C2248064A300CF95A5 /* HorizontalLayoutViewController.swift in Sources */,
+				635CB02B2E1584060032AB25 /* IdentifierChangedViewController.swift in Sources */,
 				1F46FB6B26010F4900760961 /* RefreshControlOffsetAdjustmentViewController.swift in Sources */,
 				2B56913A2846737C00E575BE /* AutoScrollingViewController2.swift in Sources */,
 				0AA4D9C6248064A300CF95A5 /* SwipeActionsViewController.swift in Sources */,

--- a/Demo/Sources/Demos/Demo Screens/IdentifierChangedViewController.swift
+++ b/Demo/Sources/Demos/Demo Screens/IdentifierChangedViewController.swift
@@ -1,0 +1,71 @@
+//
+//  IdentifierChangedViewController.swift
+//  Demo
+//
+//  Created by Sebastian Celis on 7/2/25.
+//  Copyright © 2025 Kyle Van Essen. All rights reserved.
+//
+
+import ListableUI
+import BlueprintUI
+import BlueprintUICommonControls
+import BlueprintUILists
+
+final class IdentifierChangedViewController : ListViewController {
+
+    var identifier = UUID() {
+        didSet {
+            reload(animated: true)
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(title: "Change", style: .plain, target: self, action: #selector(change)),
+        ]
+    }
+
+    @objc private func change() {
+        identifier = UUID()
+    }
+
+    override func configure(list: inout ListProperties) {
+        list.identifier = identifier
+        list.layout = .demoLayout
+
+        list("items") { section in
+            section += (1...100).map { number in
+                Item(ItemRow(identifier: identifier, number: number)) { item in
+                    item.selectionStyle = .tappable
+                }
+            }
+        }
+    }
+}
+
+fileprivate struct ItemRow : BlueprintItemContent, Equatable {
+    var identifier : UUID
+    var number : Int
+
+    var name : String {
+        "Row \(number) \(identifier.uuidString.prefix(8))"
+    }
+
+    var identifierValue: String {
+        "\(number)"
+    }
+
+    func element(with info: ApplyItemContentInfo) -> Element {
+        Row { row in
+            row.verticalAlignment = .center
+
+            row.addFlexible(child: Label(text: self.name) { label in
+                label.font = .systemFont(ofSize: 18.0, weight: .semibold)
+            })
+        }
+        .inset(uniform: 10.0)
+        .box(background: .white(0.95), corners: .rounded(radius: 10))
+    }
+}

--- a/Demo/Sources/Demos/DemosRootViewController.swift
+++ b/Demo/Sources/Demos/DemosRootViewController.swift
@@ -235,6 +235,14 @@ public final class DemosRootViewController : ListViewController
                         self?.push(AutoLayoutDemoViewController())
                     }
                 )
+
+                Item(
+                    DemoItem(text: "Changing Identifiers"),
+                    selectionStyle: .tappable,
+                    onSelect: { _ in
+                        self?.push(IdentifierChangedViewController())
+                    }
+                )
             } header: {
                 DemoHeader(title: "List Views")
             }

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1368,6 +1368,9 @@ public final class ListView : UIView
             // Update the offset of the scroll view to show the refresh control if needed
             presentationState.adjustContentOffsetForRefreshControl(in: self.collectionView)
 
+            // Perform any needed offset adjustments due to the reason
+            self.updateContentOffset(for: reason)
+
             // Perform any needed auto scroll actions.
             self.performAutoScrollAction(with: diff.changes.addedItemIdentifiers, animated: reason.animated)
 
@@ -1416,7 +1419,19 @@ public final class ListView : UIView
             }
         }
     }
-    
+
+    private func updateContentOffset(for reason: PresentationState.UpdateReason) {
+        switch reason {
+        case .contentChanged(_, let identifierChanged):
+            if identifierChanged {
+                let contentOffset = CGPoint(x: 0, y: -collectionView.adjustedContentInset.top)
+                collectionView.setContentOffset(contentOffset, animated: false)
+            }
+        default:
+            break
+        }
+    }
+
     private func performAutoScrollAction(with addedItems : Set<AnyIdentifier>, animated : Bool)
     {
         switch self.autoScrollAction {

--- a/ListableUI/Tests/ListView/ListViewTests.swift
+++ b/ListableUI/Tests/ListView/ListViewTests.swift
@@ -1231,7 +1231,35 @@ class ListViewTests: XCTestCase
             }
         }
     }
-    
+
+    func test_changing_identifier_resets_content_offset() {
+        let listView = ListView(frame: CGRect(x: 0, y: 0, width: 200, height: 400))
+
+        func configureList(identifier: String) {
+            listView.configure { list in
+                list.identifier = identifier
+
+                list += Section("a-section") { section in
+                    for row in 1...100 {
+                        section += Item(
+                            TestContent(content: row),
+                            sizing: .fixed(height: 50)
+                        )
+                    }
+                }
+            }
+        }
+
+        configureList(identifier: "first")
+        listView.collectionView.contentOffset.y = 100
+        self.waitForOneRunloop()
+
+        configureList(identifier: "second")
+        self.waitForOneRunloop()
+        XCTAssertEqual(listView.collectionView.contentOffset.y, 0, accuracy: 0.1)
+    }
+
+
     /// A helper function for a test case that creates and presents a `ViewController`
     /// with a list of 100 rows.
     /// - Parameters:


### PR DESCRIPTION
If a List’s identifier changes, we should automatically scroll to the top because maintaining scroll position from one list to another doesn’t make sense if the identifier (and thus list itself) completely changes.

Reseting the scroll position to the top in this scenario should be done without animation.

https://block.atlassian.net/browse/UI-8965

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
