### PR TITLE
fix: Ensure we're referencing up-to-date swipe state when configuring interaction enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fixed an issue where a full swipe of a swipe action could result in the cell being temporarily unresponsive.
+
 ### Added
 
 ### Removed

--- a/Development/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
+++ b/Development/Sources/Demos/Demo Screens/SwipeActionsViewController.swift
@@ -333,6 +333,9 @@ final class SwipeActionsViewController: UIViewController  {
                 .inset(uniform: 16)
             }
             .accessibilityElement(label: "Swipeable Item", value: item.title, traits: [.button])
+            .tappable {
+                print("Tapped \(item.title)")
+            }
         }
     }
 

--- a/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
+++ b/ListableUI/Sources/Internal/ItemCell.ContentViewContainer.swift
@@ -286,8 +286,11 @@ extension ItemCell {
         private func set(state: SwipeActionState, animated: Bool = false) {
             swipeState = state
 
+            // Warning! : `swipeState` may be mutated to a new value via it's property
+            // observers and may not equal `state` at this point!
+
             // We don't want any actions on the content view while our swipe actions are open.
-            self.contentView.isUserInteractionEnabled = switch state {
+            self.contentView.isUserInteractionEnabled = switch swipeState {
             case .closed:
                 true
             case .expandActions, .open, .swiping, .willPerformFirstActionAutomatically:


### PR DESCRIPTION
For https://block.atlassian.net/browse/UI-9091

This resolves an issue where a cell would not respond to taps after the "full swipe" swipe action trigger.

The issue was that we were referencing stale swipe state when configuring `isUserInteractionEnabled`. It was quite unintuitive when debugging this, but the line `swipeState = state` immediately resulted in those variables holding different values while processing the swipe action 🙃. We would incorrectly fall into the `.willPerformFirstActionAutomatically` case, making the content view unresponsive, despite the `swipeState` reporting as `.closed`.

The SwipeActionsViewController has also been updated to demonstrate this is now working as expected.

### Checklist

Please do the following before merging:

- [ ] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
