### PR TITLE
feat(ios): Remove check of iOS 16.4 Workaround feature flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- The iOS 16.4 first responder workaround no longer checks UserDefaults, the workaround is always applied.
+
 ### Misc
 
 ### Internal

--- a/ListableUI/Sources/ListView/ListView+iOS16.4Workaround.swift
+++ b/ListableUI/Sources/ListView/ListView+iOS16.4Workaround.swift
@@ -263,19 +263,6 @@ extension ListView {
                 return super_function(self, selector)
             }
             
-            /// In case this workaround goes wrong somehow, we'll write a go/feature controlled flag
-            /// into `UserDefaults` in POS, and then read it here. This will allow us to disable the workaround
-            /// remotely if needed.
-            ///
-            /// Note: We are explicitly **not** making this a static value, so it can be changed across reads.
-            let workaroundEnabled = UserDefaults.standard.object(
-                forKey: "Listable.EnableIOS164FirstResponderWorkaround"
-            ) as? NSNumber ?? NSNumber(booleanLiteral: true)
-
-            guard workaroundEnabled.boolValue == true else {
-                return super_function(self, selector)
-            }
-            
             guard Self.hasFirstResponderViewProperty else {
                 assertionFailure("UICollectionView no longer has an ivar named `_firstResponderView`.")
                 return super_function(self, selector)


### PR DESCRIPTION
POS is no longer using this feature flag ([PR](https://github.com/squareup/ios-register/pull/132564)) and this workaround has been in the wild long enough that we're comfortable continuing to use it by default.

There's also a [Listable PR](https://github.com/squareup/ios-register/pull/132564) to remove the check on this `UserDefaults` key entirely.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.
