### PR TITLE
Fix CollectionViewLayout delegate lifetime

### DIFF
--- a/ListableUI/Sources/Layout/CollectionViewLayout.swift
+++ b/ListableUI/Sources/Layout/CollectionViewLayout.swift
@@ -14,7 +14,7 @@ final class CollectionViewLayout : UICollectionViewLayout
     // MARK: Properties
     //
 
-    unowned let delegate : CollectionViewLayoutDelegate
+    private(set) weak var delegate : CollectionViewLayoutDelegate?
 
     var layoutDescription : LayoutDescription
 
@@ -63,7 +63,7 @@ final class CollectionViewLayout : UICollectionViewLayout
     //
 
     init(
-        delegate : CollectionViewLayoutDelegate,
+        delegate : CollectionViewLayoutDelegate?,
         layoutDescription : LayoutDescription,
         appearance : Appearance,
         behavior : Behavior
@@ -221,8 +221,8 @@ final class CollectionViewLayout : UICollectionViewLayout
         /// processing any further updates 🥴.
         ///
 
-        OperationQueue.main.addOperation {
-            self.delegate.listViewShouldEndQueueingEditsForReorder()
+        OperationQueue.main.addOperation { [weak self] in
+            self?.delegate?.listViewShouldEndQueueingEditsForReorder()
         }
     }
 
@@ -390,6 +390,10 @@ final class CollectionViewLayout : UICollectionViewLayout
 
         self.changesDuringCurrentUpdate = UpdateItems(with: [])
 
+        guard let delegate = self.delegate else {
+            return
+        }
+
         let size = self.collectionView?.bounds.size ?? .zero
 
         self.neededLayoutType.update(with: {
@@ -402,18 +406,18 @@ final class CollectionViewLayout : UICollectionViewLayout
             case .none:
                 return true
             case .relayout:
-                self.performLayout()
+                self.performLayout(delegate: delegate)
             case .rebuild:
-                self.performRebuild(andLayout: shouldLayout)
+                self.performRebuild(andLayout: shouldLayout, delegate: delegate)
             }
 
             return true
         }())
 
-        self.performLayoutUpdate()
+        self.performLayoutUpdate(delegate: delegate)
 
         if self.isReordering == false {
-            self.delegate.listViewLayoutDidLayoutContents()
+            delegate.listViewLayoutDidLayoutContents()
         }
     }
 
@@ -439,7 +443,7 @@ final class CollectionViewLayout : UICollectionViewLayout
     // MARK: Performing Layouts
     //
 
-    private func performRebuild(andLayout layout : Bool)
+    private func performRebuild(andLayout layout : Bool, delegate : CollectionViewLayoutDelegate)
     {
         self.previousLayout = self.layout
 
@@ -447,7 +451,7 @@ final class CollectionViewLayout : UICollectionViewLayout
             appearance: self.appearance,
             behavior: self.behavior,
             content: {
-                self.delegate.listLayoutContent(defaults: $0)
+                delegate.listLayoutContent(defaults: $0)
             }
         )
 
@@ -459,34 +463,34 @@ final class CollectionViewLayout : UICollectionViewLayout
         )
 
         if layout {
-            self.performLayout()
+            self.performLayout(delegate: delegate)
         }
     }
 
-    private func performLayout()
+    private func performLayout(delegate : CollectionViewLayoutDelegate)
     {
         let view = self.collectionView!
 
         let context = ListLayoutLayoutContext(
             collectionView: view,
-            environment: self.delegate.listViewLayoutCurrentEnvironment()
+            environment: delegate.listViewLayoutCurrentEnvironment()
         )
 
         self.layout.performLayout(
-            with: self.delegate,
+            with: delegate,
             in: context
         )
 
         self.viewProperties = CollectionViewLayoutProperties(collectionView: view)
     }
 
-    private func performLayoutUpdate()
+    private func performLayoutUpdate(delegate : CollectionViewLayoutDelegate)
     {
         let view = self.collectionView!
 
         let context = ListLayoutLayoutContext(
             collectionView: view,
-            environment: self.delegate.listViewLayoutCurrentEnvironment()
+            environment: delegate.listViewLayoutCurrentEnvironment()
         )
 
         self.layout.positionStickyListHeaderIfNeeded(in: context)

--- a/ListableUI/Sources/Layout/CollectionViewLayout.swift
+++ b/ListableUI/Sources/Layout/CollectionViewLayout.swift
@@ -221,8 +221,8 @@ final class CollectionViewLayout : UICollectionViewLayout
         /// processing any further updates 🥴.
         ///
 
-        OperationQueue.main.addOperation { [weak self] in
-            self?.delegate?.listViewShouldEndQueueingEditsForReorder()
+        OperationQueue.main.addOperation { [weak delegate = self.delegate] in
+            delegate?.listViewShouldEndQueueingEditsForReorder()
         }
     }
 

--- a/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
+++ b/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
@@ -1,0 +1,53 @@
+//
+//  CollectionViewLayoutTests.swift
+//  ListableUI-Unit-Tests
+//
+//  Created by OpenAI on 5/2/26.
+//
+
+import XCTest
+@testable import ListableUI
+
+
+final class CollectionViewLayoutTests : XCTestCase
+{
+    func test_prepare_whenDelegateHasBeenDeallocated()
+    {
+        var delegate : CollectionViewLayoutDelegateMock? = CollectionViewLayoutDelegateMock()
+        weak var weakDelegate = delegate
+
+        let layout = CollectionViewLayout(
+            delegate: delegate!,
+            layoutDescription: .table(),
+            appearance: Appearance(),
+            behavior: Behavior()
+        )
+
+        delegate = nil
+
+        XCTAssertNil(weakDelegate)
+        XCTAssertNil(layout.delegate)
+
+        layout.prepare()
+    }
+}
+
+
+private final class CollectionViewLayoutDelegateMock : CollectionViewLayoutDelegate
+{
+    func listViewLayoutUpdatedItemPositions() {}
+
+    func listLayoutContent(
+        defaults: ListLayoutDefaults
+    ) -> ListLayoutContent {
+        ListLayoutContent()
+    }
+
+    func listViewLayoutCurrentEnvironment() -> ListEnvironment {
+        .empty
+    }
+
+    func listViewLayoutDidLayoutContents() {}
+
+    func listViewShouldEndQueueingEditsForReorder() {}
+}

--- a/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
+++ b/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
@@ -13,17 +13,19 @@ final class CollectionViewLayoutTests : XCTestCase
 {
     func test_prepare_whenDelegateHasBeenDeallocated()
     {
-        var delegate : CollectionViewLayoutDelegateMock? = CollectionViewLayoutDelegateMock()
-        weak var weakDelegate = delegate
+        weak var weakDelegate : CollectionViewLayoutDelegateMock?
 
-        let layout = CollectionViewLayout(
-            delegate: delegate!,
-            layoutDescription: .table(),
-            appearance: Appearance(),
-            behavior: Behavior()
-        )
+        let layout : CollectionViewLayout = {
+            let delegate = CollectionViewLayoutDelegateMock()
+            weakDelegate = delegate
 
-        delegate = nil
+            return CollectionViewLayout(
+                delegate: delegate,
+                layoutDescription: .table(),
+                appearance: Appearance(),
+                behavior: Behavior()
+            )
+        }()
 
         XCTAssertNil(weakDelegate)
         XCTAssertNil(layout.delegate)

--- a/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
+++ b/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
@@ -2,7 +2,7 @@
 //  CollectionViewLayoutTests.swift
 //  ListableUI-Unit-Tests
 //
-//  Created by OpenAI on 5/2/26.
+//  Created by Alex Odawa on 5/2/26.
 //
 
 import XCTest


### PR DESCRIPTION
Changes the `CollectionViewLayout` delegate from `unowned` to `weak` so the layout no longer crashes if the delegate is deallocated before the layout is. Internal layout helpers now take the delegate as a parameter, the async `listViewShouldEndQueueingEditsForReorder` callback uses `[weak self]`, and `prepare()` bails out if the delegate is gone. Adds a regression test that deallocates the delegate before calling `prepare()`.

### Checklist

Please do the following before merging:

- [ ] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.