### PR TITLE
Fix CollectionViewLayout delegate lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fixed a crash in `CollectionViewLayout` when the delegate was deallocated before the layout. The delegate is now held weakly rather than unowned.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/Layout/CollectionViewLayout.swift
+++ b/ListableUI/Sources/Layout/CollectionViewLayout.swift
@@ -14,7 +14,7 @@ final class CollectionViewLayout : UICollectionViewLayout
     // MARK: Properties
     //
 
-    unowned let delegate : CollectionViewLayoutDelegate
+    private(set) weak var delegate : CollectionViewLayoutDelegate?
 
     var layoutDescription : LayoutDescription
 
@@ -221,8 +221,10 @@ final class CollectionViewLayout : UICollectionViewLayout
         /// processing any further updates 🥴.
         ///
 
-        OperationQueue.main.addOperation {
-            self.delegate.listViewShouldEndQueueingEditsForReorder()
+        let delegate = self.delegate
+
+        OperationQueue.main.addOperation { [weak delegate] in
+            delegate?.listViewShouldEndQueueingEditsForReorder()
         }
     }
 
@@ -390,6 +392,10 @@ final class CollectionViewLayout : UICollectionViewLayout
 
         self.changesDuringCurrentUpdate = UpdateItems(with: [])
 
+        guard let delegate = self.delegate else {
+            return
+        }
+
         let size = self.collectionView?.bounds.size ?? .zero
 
         self.neededLayoutType.update(with: {
@@ -402,18 +408,18 @@ final class CollectionViewLayout : UICollectionViewLayout
             case .none:
                 return true
             case .relayout:
-                self.performLayout()
+                self.performLayout(delegate: delegate)
             case .rebuild:
-                self.performRebuild(andLayout: shouldLayout)
+                self.performRebuild(andLayout: shouldLayout, delegate: delegate)
             }
 
             return true
         }())
 
-        self.performLayoutUpdate()
+        self.performLayoutUpdate(delegate: delegate)
 
         if self.isReordering == false {
-            self.delegate.listViewLayoutDidLayoutContents()
+            delegate.listViewLayoutDidLayoutContents()
         }
     }
 
@@ -439,7 +445,7 @@ final class CollectionViewLayout : UICollectionViewLayout
     // MARK: Performing Layouts
     //
 
-    private func performRebuild(andLayout layout : Bool)
+    private func performRebuild(andLayout layout : Bool, delegate : CollectionViewLayoutDelegate)
     {
         self.previousLayout = self.layout
 
@@ -447,7 +453,7 @@ final class CollectionViewLayout : UICollectionViewLayout
             appearance: self.appearance,
             behavior: self.behavior,
             content: {
-                self.delegate.listLayoutContent(defaults: $0)
+                delegate.listLayoutContent(defaults: $0)
             }
         )
 
@@ -459,34 +465,34 @@ final class CollectionViewLayout : UICollectionViewLayout
         )
 
         if layout {
-            self.performLayout()
+            self.performLayout(delegate: delegate)
         }
     }
 
-    private func performLayout()
+    private func performLayout(delegate : CollectionViewLayoutDelegate)
     {
         let view = self.collectionView!
 
         let context = ListLayoutLayoutContext(
             collectionView: view,
-            environment: self.delegate.listViewLayoutCurrentEnvironment()
+            environment: delegate.listViewLayoutCurrentEnvironment()
         )
 
         self.layout.performLayout(
-            with: self.delegate,
+            with: delegate,
             in: context
         )
 
         self.viewProperties = CollectionViewLayoutProperties(collectionView: view)
     }
 
-    private func performLayoutUpdate()
+    private func performLayoutUpdate(delegate : CollectionViewLayoutDelegate)
     {
         let view = self.collectionView!
 
         let context = ListLayoutLayoutContext(
             collectionView: view,
-            environment: self.delegate.listViewLayoutCurrentEnvironment()
+            environment: delegate.listViewLayoutCurrentEnvironment()
         )
 
         self.layout.positionStickyListHeaderIfNeeded(in: context)

--- a/ListableUI/Sources/ListView/ListView.LayoutManager.swift
+++ b/ListableUI/Sources/ListView/ListView.LayoutManager.swift
@@ -45,8 +45,12 @@ extension ListView
                     self.collectionViewLayout.setNeedsRebuild(animated: animated)
                 }
             } else {
+                guard let delegate = self.collectionViewLayout.delegate else {
+                    listableInternalFatal("Cannot swap layout when the previous layout's delegate has been deallocated.")
+                }
+
                 self.collectionViewLayout = CollectionViewLayout(
-                    delegate: self.collectionViewLayout.delegate,
+                    delegate: delegate,
                     layoutDescription: layout,
                     appearance: self.collectionViewLayout.appearance,
                     behavior: self.collectionViewLayout.behavior

--- a/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
+++ b/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
@@ -1,0 +1,55 @@
+//
+//  CollectionViewLayoutTests.swift
+//  ListableUI-Unit-Tests
+//
+//  Created by Alex Odawa on 5/2/26.
+//
+
+import XCTest
+@testable import ListableUI
+
+
+final class CollectionViewLayoutTests : XCTestCase
+{
+    func test_prepare_whenDelegateHasBeenDeallocated()
+    {
+        weak var weakDelegate : CollectionViewLayoutDelegateMock?
+
+        let layout : CollectionViewLayout = {
+            let delegate = CollectionViewLayoutDelegateMock()
+            weakDelegate = delegate
+
+            return CollectionViewLayout(
+                delegate: delegate,
+                layoutDescription: .table(),
+                appearance: Appearance(),
+                behavior: Behavior()
+            )
+        }()
+
+        XCTAssertNil(weakDelegate)
+        XCTAssertNil(layout.delegate)
+
+        layout.prepare()
+    }
+}
+
+
+private final class CollectionViewLayoutDelegateMock : CollectionViewLayoutDelegate
+{
+    func listViewLayoutUpdatedItemPositions() {}
+
+    func listLayoutContent(
+        defaults: ListLayoutDefaults
+    ) -> ListLayoutContent {
+        ListLayoutContent()
+    }
+
+    func listViewLayoutCurrentEnvironment() -> ListEnvironment {
+        .empty
+    }
+
+    func listViewLayoutDidLayoutContents() {}
+
+    func listViewShouldEndQueueingEditsForReorder() {}
+}


### PR DESCRIPTION
## Problem

`CollectionViewLayout` held its delegate as `unowned let`. In normal use the `ListView` ownership graph keeps the delegate alive for the layout's whole lifetime, but a layout swap (`LayoutManager.set(layout:)`) or test setup that constructs a layout in isolation can deallocate the delegate first, leaving a dangling `unowned` reference and a hard crash on next access.

## Fix

Change `delegate` from `unowned let` to `private(set) weak var`, and tighten the surrounding call sites:

- `prepare()` reads the delegate once at the top, returns early if it's gone, and threads the unwrapped reference through `performLayout`, `performRebuild`, and `performLayoutUpdate` to avoid per-call weak loads.
- `init` keeps a non-optional delegate parameter; the weak storage already conveys "may vanish later," and the parameter keeps construction honest.
- `LayoutManager.set(layout:)` uses `listableInternalFatal` if the outgoing layout's delegate has been deallocated, since silently dropping a layout swap is worse than crashing on a "should never happen" state.
- `sendEndQueuingEditsAfterDelay()` snapshots the delegate locally and weak-captures it, so the closure neither pins `self` nor extends the delegate's lifetime past its natural end.

## Test

Adds `CollectionViewLayoutTests.test_prepare_whenDelegateHasBeenDeallocated`, which constructs a layout with a mock delegate, drops the strong reference, asserts the weak references are nil, and calls `prepare()` to verify it doesn't crash.

Verified locally that the test fails against `origin/main`'s source and passes with this PR's fix.

**Before** (against `origin/main`'s `unowned let delegate`):

```
Test Case '-[ListableTests.CollectionViewLayoutTests test_prepare_whenDelegateHasBeenDeallocated]' started.
Fatal error: Attempted to read an unowned reference but object 0x1027ed7a0 was already destroyed
** TEST FAILED **
```

**After** (this PR):

```
Test Case '-[ListableTests.CollectionViewLayoutTests test_prepare_whenDelegateHasBeenDeallocated]' started.
Test Case '-[ListableTests.CollectionViewLayoutTests test_prepare_whenDelegateHasBeenDeallocated]' passed (0.001 seconds).
** TEST SUCCEEDED **
```

## Risk

Low. `ListView` retains its `Delegate` for its entire lifetime, so in normal flows the delegate is alive every time the layout uses it. The fix is defense-in-depth for layout swaps and isolated-construction paths.

### Checklist

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.