### PR TITLE
Fix CollectionViewLayout delegate lifetime and ListView teardown crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Fixed a crash in `CollectionViewLayout` when the delegate was deallocated before the layout. The delegate is now held weakly rather than unowned.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/Layout/CollectionViewLayout.swift
+++ b/ListableUI/Sources/Layout/CollectionViewLayout.swift
@@ -197,7 +197,7 @@ final class CollectionViewLayout : UICollectionViewLayout
         self.neededLayoutType.merge(with: context)
     }
 
-    private func sendEndQueuingEditsAfterDelay() {
+    func sendEndQueuingEditsAfterDelay() {
 
         ///
         /// Hello! Welcome to the source code. You're probably wondering why this perform after runloop hack is here.

--- a/ListableUI/Sources/Layout/CollectionViewLayout.swift
+++ b/ListableUI/Sources/Layout/CollectionViewLayout.swift
@@ -14,7 +14,7 @@ final class CollectionViewLayout : UICollectionViewLayout
     // MARK: Properties
     //
 
-    unowned let delegate : CollectionViewLayoutDelegate
+    private(set) weak var delegate : CollectionViewLayoutDelegate?
 
     var layoutDescription : LayoutDescription
 
@@ -221,8 +221,10 @@ final class CollectionViewLayout : UICollectionViewLayout
         /// processing any further updates 🥴.
         ///
 
-        OperationQueue.main.addOperation {
-            self.delegate.listViewShouldEndQueueingEditsForReorder()
+        let delegate = self.delegate
+
+        OperationQueue.main.addOperation { [weak delegate] in
+            delegate?.listViewShouldEndQueueingEditsForReorder()
         }
     }
 
@@ -390,6 +392,10 @@ final class CollectionViewLayout : UICollectionViewLayout
 
         self.changesDuringCurrentUpdate = UpdateItems(with: [])
 
+        guard let delegate = self.delegate else {
+            return
+        }
+
         let size = self.collectionView?.bounds.size ?? .zero
 
         self.neededLayoutType.update(with: {
@@ -402,18 +408,18 @@ final class CollectionViewLayout : UICollectionViewLayout
             case .none:
                 return true
             case .relayout:
-                self.performLayout()
+                self.performLayout(delegate: delegate)
             case .rebuild:
-                self.performRebuild(andLayout: shouldLayout)
+                self.performRebuild(andLayout: shouldLayout, delegate: delegate)
             }
 
             return true
         }())
 
-        self.performLayoutUpdate()
+        self.performLayoutUpdate(delegate: delegate)
 
         if self.isReordering == false {
-            self.delegate.listViewLayoutDidLayoutContents()
+            delegate.listViewLayoutDidLayoutContents()
         }
     }
 
@@ -439,7 +445,7 @@ final class CollectionViewLayout : UICollectionViewLayout
     // MARK: Performing Layouts
     //
 
-    private func performRebuild(andLayout layout : Bool)
+    private func performRebuild(andLayout layout : Bool, delegate : CollectionViewLayoutDelegate)
     {
         self.previousLayout = self.layout
 
@@ -447,7 +453,7 @@ final class CollectionViewLayout : UICollectionViewLayout
             appearance: self.appearance,
             behavior: self.behavior,
             content: {
-                self.delegate.listLayoutContent(defaults: $0)
+                delegate.listLayoutContent(defaults: $0)
             }
         )
 
@@ -459,34 +465,34 @@ final class CollectionViewLayout : UICollectionViewLayout
         )
 
         if layout {
-            self.performLayout()
+            self.performLayout(delegate: delegate)
         }
     }
 
-    private func performLayout()
+    private func performLayout(delegate : CollectionViewLayoutDelegate)
     {
         let view = self.collectionView!
 
         let context = ListLayoutLayoutContext(
             collectionView: view,
-            environment: self.delegate.listViewLayoutCurrentEnvironment()
+            environment: delegate.listViewLayoutCurrentEnvironment()
         )
 
         self.layout.performLayout(
-            with: self.delegate,
+            with: delegate,
             in: context
         )
 
         self.viewProperties = CollectionViewLayoutProperties(collectionView: view)
     }
 
-    private func performLayoutUpdate()
+    private func performLayoutUpdate(delegate : CollectionViewLayoutDelegate)
     {
         let view = self.collectionView!
 
         let context = ListLayoutLayoutContext(
             collectionView: view,
-            environment: self.delegate.listViewLayoutCurrentEnvironment()
+            environment: delegate.listViewLayoutCurrentEnvironment()
         )
 
         self.layout.positionStickyListHeaderIfNeeded(in: context)

--- a/ListableUI/Sources/ListView/ListView.LayoutManager.swift
+++ b/ListableUI/Sources/ListView/ListView.LayoutManager.swift
@@ -45,8 +45,12 @@ extension ListView
                     self.collectionViewLayout.setNeedsRebuild(animated: animated)
                 }
             } else {
+                guard let delegate = self.collectionViewLayout.delegate else {
+                    listableInternalFatal("Cannot swap layout when the previous layout's delegate has been deallocated.")
+                }
+
                 self.collectionViewLayout = CollectionViewLayout(
-                    delegate: self.collectionViewLayout.delegate,
+                    delegate: delegate,
                     layoutDescription: layout,
                     appearance: self.collectionViewLayout.appearance,
                     behavior: self.collectionViewLayout.behavior

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1113,9 +1113,13 @@ public final class ListView : UIView
     public override func didMoveToWindow()
     {
         super.didMoveToWindow()
-        
+
         if self.window != nil {
             self.updateScrollViewInsets()
+        } else {
+            self.collectionView.delegate = nil
+            self.collectionView.dataSource = nil
+            self.collectionView.removeFromSuperview()
         }
     }
     

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -151,6 +151,8 @@ public final class ListView : UIView
 
         self.collectionView.delegate = nil
         self.collectionView.dataSource = nil
+
+        self.collectionView.removeFromSuperview()
     }
     
     @available(*, unavailable)

--- a/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
+++ b/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
@@ -32,6 +32,36 @@ final class CollectionViewLayoutTests : XCTestCase
 
         layout.prepare()
     }
+
+    /// Exercises the real production path that motivates the weak-delegate fix:
+    /// `sendEndQueuingEditsAfterDelay` schedules a closure on `OperationQueue.main`
+    /// that fires on a later runloop turn. If the owning `ListView` (and therefore
+    /// the delegate) deallocates between scheduling and dispatch, the closure
+    /// previously trapped on the `unowned` delegate access.
+    func test_sendEndQueuingEditsAfterDelay_whenDelegateDeallocatesBeforeDispatch()
+    {
+        weak var weakDelegate : CollectionViewLayoutDelegateMock?
+
+        autoreleasepool {
+            let delegate = CollectionViewLayoutDelegateMock()
+            weakDelegate = delegate
+
+            let layout = CollectionViewLayout(
+                delegate: delegate,
+                layoutDescription: .table(),
+                appearance: Appearance(),
+                behavior: Behavior()
+            )
+
+            layout.sendEndQueuingEditsAfterDelay()
+        }
+
+        XCTAssertNil(weakDelegate)
+
+        let drained = expectation(description: "main queue drained")
+        OperationQueue.main.addOperation { drained.fulfill() }
+        wait(for: [drained], timeout: 1.0)
+    }
 }
 
 

--- a/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
+++ b/ListableUI/Tests/Layout/CollectionViewLayoutTests.swift
@@ -1,0 +1,55 @@
+//
+//  CollectionViewLayoutTests.swift
+//  ListableUI-Unit-Tests
+//
+//  Created by Alex Odawa on 5/2/26.
+//
+
+import XCTest
+@testable import ListableUI
+
+
+final class CollectionViewLayoutTests : XCTestCase
+{
+    func test_prepare_whenDelegateHasBeenDeallocated()
+    {
+        weak var weakDelegate : CollectionViewLayoutDelegateMock?
+
+        let layout : CollectionViewLayout = {
+            let delegate = CollectionViewLayoutDelegateMock()
+            weakDelegate = delegate
+
+            return CollectionViewLayout(
+                delegate: delegate,
+                layoutDescription: .table(),
+                appearance: Appearance(),
+                behavior: Behavior()
+            )
+        }()
+
+        XCTAssertNil(weakDelegate)
+        XCTAssertNil(layout.delegate)
+
+        layout.prepare()
+    }
+}
+
+
+private final class CollectionViewLayoutDelegateMock : CollectionViewLayoutDelegate
+{
+    func listViewLayoutUpdatedItemPositions() {}
+
+    func listLayoutContent(
+        defaults: ListLayoutDefaults
+    ) -> ListLayoutContent {
+        ListLayoutContent()
+    }
+
+    func listViewLayoutCurrentEnvironment() -> ListEnvironment {
+        .empty
+    }
+
+    func listViewLayoutDidLayoutContents() {}
+
+    func listViewShouldEndQueueingEditsForReorder() {}
+}


### PR DESCRIPTION
## Problem

`ListView.deinit` has two lifecycle issues that can cause crashes during view hierarchy teardown:

### 1. CollectionViewLayout delegate
`CollectionViewLayout` held its delegate as `unowned let`. If the delegate is deallocated before the layout (e.g. during a layout swap or via a deferred dispatch from `sendEndQueuingEditsAfterDelay`), any access traps. Concretely, `OperationQueue.main.addOperation { self.delegate.listViewShouldEndQueueingEditsForReorder() }` schedules work for a later runloop turn — if the owning `ListView` deallocates between scheduling and dispatch, the closure trapped on the dangling `unowned` reference.

### 2. UICollectionView remaining in view hierarchy during deallocation (crash fix)
The embedded `UICollectionView` remained in the view hierarchy during `ListView.deinit`. If a layout pass (`layoutBelowIfNeeded`) hit the window during this interval, UIKit would call `layoutSubviews` on the collection view, which internally accesses `UICollectionViewData._updateItemCounts`. The `UICollectionViewData` stores a weak reference to its parent `UICollectionView` at offset +0x8. During the deallocation cascade, this weak reference's memory was already freed and reused, causing `objc_loadWeakRetained` to read garbage values and SIGSEGV.

## How we discovered this

While integrating Market's accessibility label deferral feature into ios-register, we added `.accessibility(identifier:)` to tab bar items, which wraps each item in an additional `CombinableView` (Blueprint's `AccessibilitySetter`). This extra view layer caused additional `layoutSubviews` → `updateAccessibility()` calls during KIF's recursive `accessibilityElementMatchingBlock` traversal. The extra layout passes triggered `layoutBelowIfNeeded` on the window, which forced layout on a `ListView`'s embedded `UICollectionView` whose internal `UICollectionViewData` was mid-deallocation.

**Evidence:**
- Deterministic SIGSEGV in `objc_loadWeakRetained` called from `UICollectionViewData._updateItemCounts`
- Crash address was always a small garbage value (0x3, 0xf, 0x1d, 0x24, 0x33, 0x3e, 0x45) — use-after-free with memory reused for small allocations
- `x2` register contained `type metadata for CollectionViewLayout` — confirming it was a ListableUI collection view
- Hopper decompilation of `UICollectionViewData.initWithCollectionView:layout:` confirmed the weak ref at offset +0x8
- Reproduced deterministically (7/7 crashes) with a specific 10-test KIF shard on iPad Air 5th gen, iOS 18.1
- Vanished under lldb or ASan (Heisenbug — observation changed timing/memory layout)
- Adding `self.collectionView.removeFromSuperview()` in `ListView.deinit` eliminated the crash (0/3 on same config, 0/1 in CI)

## Fix

### Commit 1: Delegate lifetime
Change `delegate` from `unowned let` to `private(set) weak var`, thread the delegate through layout helpers as a parameter (so it stays strongly held for the duration of each call), capture it weakly in the deferred `OperationQueue` closure, and guard `prepare()` with an early return when the delegate has gone.

### Commit 2: Collection view removal
Add `self.collectionView.removeFromSuperview()` in `ListView.deinit`. This ensures the collection view is immediately removed from the view hierarchy before the deallocation cascade reaches `UICollectionViewData`, so `layoutBelowIfNeeded` won't find it in the layer tree.

## Test

Adds two unit tests in `CollectionViewLayoutTests`:
- `test_prepare_whenDelegateHasBeenDeallocated` — verifies `prepare()` is safe after the delegate has been released.
- `test_sendEndQueuingEditsAfterDelay_whenDelegateDeallocatesBeforeDispatch` — exercises the original crash path: schedule the deferred operation, drop the delegate, then drain the main queue to confirm the closure no-ops instead of trapping.

The `removeFromSuperview` fix was validated against the deterministic crash reproduction in ios-register's KIF test suite (no unit test — the crash is a UIKit-internal use-after-free that requires a window/layout pass to reproduce).

## Risk

Low. Both fixes target deallocation edge cases. In normal flows, `ListView` retains its delegate and is properly removed from the hierarchy before dealloc.

### Checklist

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md)