### PR TITLE
Add custom item offset scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@
 
 ### Added
 
-- Added item-aware content offset adjustment APIs and scroll-in-progress state for custom scrolling behaviors.
+- Added item-aware content offset adjustment APIs, declarative auto-scroll support, and scroll-in-progress state for custom scrolling behaviors.
+  ```swift
+  list.autoScrollAction = .pin(
+      .item(targetIdentifier),
+      itemPosition: .verticalContentOffsetAdjustment { info in
+          max(0.0, info.itemFrame.maxY - info.visibleContentFrame.maxY)
+      },
+      scrollInterruptionPolicy: .deferDuringUserScrolling
+  )
+  ```
+  Use `.skipDuringUserScrolling` instead when the auto-scroll should be dropped rather than retried after the user scroll ends.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added item-aware content offset adjustment APIs and scroll-in-progress state for custom scrolling behaviors.
+
 ### Removed
 
 ### Changed

--- a/Development/Sources/Demos/Demo Screens/CustomAutoScrollingViewController.swift
+++ b/Development/Sources/Demos/Demo Screens/CustomAutoScrollingViewController.swift
@@ -21,6 +21,7 @@ final class CustomAutoScrollingViewController : UIViewController
     private var selectedRow = 24
     private var expandedRows = Set<Int>()
     private var hasPerformedInitialLayoutUpdate = false
+    private var animateAutoScroll = false
 
     override func loadView()
     {
@@ -53,6 +54,12 @@ final class CustomAutoScrollingViewController : UIViewController
         super.viewDidLoad()
 
         self.title = "Custom Auto Scrolling"
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(
+            title: "Toggle Animations",
+            style: .plain,
+            target: self,
+            action: #selector(toggleAnimations)
+        )
         self.updateList()
     }
 
@@ -142,6 +149,12 @@ final class CustomAutoScrollingViewController : UIViewController
         self.updateList()
     }
 
+    @objc private func toggleAnimations()
+    {
+        self.animateAutoScroll.toggle()
+        print("Auto-scroll animations are \(self.animateAutoScroll ? "on" : "off").")
+    }
+
     private func updateList()
     {
         self.footerTitle.text = "Target row \(self.selectedRow + 1) stays above the fixed footer"
@@ -160,7 +173,7 @@ final class CustomAutoScrollingViewController : UIViewController
                 itemPosition: .verticalContentOffsetAdjustment { [weak self] info in
                     self?.footerAwareScrollDelta(for: info) ?? 0.0
                 },
-                animated: false,
+                animated: self.animateAutoScroll,
                 scrollInterruptionPolicy: .deferDuringUserScrolling,
                 shouldPerform: { _ in true }
             )

--- a/Development/Sources/Demos/Demo Screens/CustomAutoScrollingViewController.swift
+++ b/Development/Sources/Demos/Demo Screens/CustomAutoScrollingViewController.swift
@@ -17,6 +17,14 @@ final class CustomAutoScrollingViewController : UIViewController
     private let list = ListView()
     private let footer = UIView()
     private let footerTitle = UILabel()
+    private lazy var animationsButton : UIBarButtonItem = {
+        UIBarButtonItem(
+            title: self.animationsButtonTitle,
+            style: .plain,
+            target: self,
+            action: #selector(toggleAnimations)
+        )
+    }()
 
     private var selectedRow = 24
     private var expandedRows = Set<Int>()
@@ -55,12 +63,7 @@ final class CustomAutoScrollingViewController : UIViewController
         super.viewDidLoad()
 
         self.title = "Custom Auto Scrolling"
-        self.navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: "Toggle Animations",
-            style: .plain,
-            target: self,
-            action: #selector(toggleAnimations)
-        )
+        self.navigationItem.rightBarButtonItem = self.animationsButton
         self.updateList()
     }
 
@@ -158,7 +161,13 @@ final class CustomAutoScrollingViewController : UIViewController
     @objc private func toggleAnimations()
     {
         self.animateAutoScroll.toggle()
+        self.updateAnimationsButtonTitle()
         print("Auto-scroll animations are \(self.animateAutoScroll ? "on" : "off").")
+    }
+
+    private func updateAnimationsButtonTitle()
+    {
+        self.animationsButton.title = self.animationsButtonTitle
     }
 
     private func updateList()
@@ -222,6 +231,10 @@ final class CustomAutoScrollingViewController : UIViewController
 
     private var scrollIndicatorBottomInset : CGFloat {
         max(0.0, self.footer.bounds.height - self.view.safeAreaInsets.bottom)
+    }
+
+    private var animationsButtonTitle : String {
+        "Animations: \(self.animateAutoScroll ? "On" : "Off")"
     }
 
     private static let rowCount = 50

--- a/Development/Sources/Demos/Demo Screens/CustomAutoScrollingViewController.swift
+++ b/Development/Sources/Demos/Demo Screens/CustomAutoScrollingViewController.swift
@@ -68,6 +68,13 @@ final class CustomAutoScrollingViewController : UIViewController
         self.updateList()
     }
 
+    override func viewSafeAreaInsetsDidChange()
+    {
+        super.viewSafeAreaInsetsDidChange()
+
+        self.updateList()
+    }
+
     private func configureFooter()
     {
         self.footer.backgroundColor = .systemBackground
@@ -146,7 +153,7 @@ final class CustomAutoScrollingViewController : UIViewController
             list.appearance = .demoAppearance
             list.layout = .demoLayout
             list.animation = .fast
-            list.scrollIndicatorInsets.bottom = 112.0
+            list.scrollIndicatorInsets.bottom = self.scrollIndicatorBottomInset
 
             list.autoScrollAction = .pin(
                 .item(targetIdentifier),
@@ -192,6 +199,10 @@ final class CustomAutoScrollingViewController : UIViewController
         }
 
         return 0.0
+    }
+
+    private var scrollIndicatorBottomInset : CGFloat {
+        max(0.0, self.footer.bounds.height - self.view.safeAreaInsets.bottom)
     }
 
     private static let rowCount = 50

--- a/Development/Sources/Demos/Demo Screens/CustomAutoScrollingViewController.swift
+++ b/Development/Sources/Demos/Demo Screens/CustomAutoScrollingViewController.swift
@@ -22,6 +22,7 @@ final class CustomAutoScrollingViewController : UIViewController
     private var expandedRows = Set<Int>()
     private var hasPerformedInitialLayoutUpdate = false
     private var animateAutoScroll = false
+    private var isSuppressingAutoScrollAnimation = false
 
     override func loadView()
     {
@@ -72,7 +73,12 @@ final class CustomAutoScrollingViewController : UIViewController
         }
 
         self.hasPerformedInitialLayoutUpdate = true
-        self.updateList()
+        self.isSuppressingAutoScrollAnimation = true
+        defer { self.isSuppressingAutoScrollAnimation = false }
+
+        UIView.performWithoutAnimation {
+            self.updateList()
+        }
     }
 
     override func viewSafeAreaInsetsDidChange()
@@ -173,7 +179,7 @@ final class CustomAutoScrollingViewController : UIViewController
                 itemPosition: .verticalContentOffsetAdjustment { [weak self] info in
                     self?.footerAwareScrollDelta(for: info) ?? 0.0
                 },
-                animated: self.animateAutoScroll,
+                animated: self.animateAutoScroll && self.isSuppressingAutoScrollAnimation == false,
                 scrollInterruptionPolicy: .deferDuringUserScrolling,
                 shouldPerform: { _ in true }
             )

--- a/Development/Sources/Demos/Demo Screens/CustomAutoScrollingViewController.swift
+++ b/Development/Sources/Demos/Demo Screens/CustomAutoScrollingViewController.swift
@@ -1,0 +1,254 @@
+//
+//  CustomAutoScrollingViewController.swift
+//  Demo
+//
+//  Created by Square on 5/22/26.
+//
+
+import BlueprintUI
+import BlueprintUICommonControls
+import BlueprintUILists
+import ListableUI
+import UIKit
+
+
+final class CustomAutoScrollingViewController : UIViewController
+{
+    private let list = ListView()
+    private let footer = UIView()
+    private let footerTitle = UILabel()
+
+    private var selectedRow = 24
+    private var expandedRows = Set<Int>()
+    private var hasPerformedInitialLayoutUpdate = false
+
+    override func loadView()
+    {
+        self.view = UIView()
+        self.view.backgroundColor = .white
+
+        self.list.translatesAutoresizingMaskIntoConstraints = false
+        self.footer.translatesAutoresizingMaskIntoConstraints = false
+
+        self.view.addSubview(self.list)
+        self.view.addSubview(self.footer)
+
+        NSLayoutConstraint.activate([
+            self.list.topAnchor.constraint(equalTo: self.view.topAnchor),
+            self.list.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            self.list.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            self.list.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+
+            self.footer.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            self.footer.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            self.footer.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            self.footer.heightAnchor.constraint(equalToConstant: 112.0),
+        ])
+
+        self.configureFooter()
+    }
+
+    override func viewDidLoad()
+    {
+        super.viewDidLoad()
+
+        self.title = "Custom Auto Scrolling"
+        self.updateList()
+    }
+
+    override func viewDidLayoutSubviews()
+    {
+        super.viewDidLayoutSubviews()
+
+        guard self.hasPerformedInitialLayoutUpdate == false else {
+            return
+        }
+
+        self.hasPerformedInitialLayoutUpdate = true
+        self.updateList()
+    }
+
+    private func configureFooter()
+    {
+        self.footer.backgroundColor = .systemBackground
+        self.footer.layer.shadowColor = UIColor.black.cgColor
+        self.footer.layer.shadowOpacity = 0.18
+        self.footer.layer.shadowRadius = 8.0
+        self.footer.layer.shadowOffset = CGSize(width: 0.0, height: -2.0)
+
+        let previous = UIButton(type: .system)
+        previous.setTitle("Previous", for: .normal)
+        previous.addTarget(self, action: #selector(selectPreviousRow), for: .touchUpInside)
+
+        let next = UIButton(type: .system)
+        next.setTitle("Next", for: .normal)
+        next.addTarget(self, action: #selector(selectNextRow), for: .touchUpInside)
+
+        let toggleHeight = UIButton(type: .system)
+        toggleHeight.setTitle("Toggle Height", for: .normal)
+        toggleHeight.addTarget(self, action: #selector(toggleSelectedRowHeight), for: .touchUpInside)
+
+        self.footerTitle.font = .systemFont(ofSize: 16.0, weight: .semibold)
+        self.footerTitle.textAlignment = .center
+
+        let buttons = UIStackView(arrangedSubviews: [previous, next, toggleHeight])
+        buttons.axis = .horizontal
+        buttons.alignment = .center
+        buttons.distribution = .equalSpacing
+        buttons.spacing = 16.0
+
+        let stack = UIStackView(arrangedSubviews: [self.footerTitle, buttons])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.spacing = 10.0
+
+        self.footer.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: self.footer.topAnchor, constant: 12.0),
+            stack.leadingAnchor.constraint(equalTo: self.footer.leadingAnchor, constant: 20.0),
+            stack.trailingAnchor.constraint(equalTo: self.footer.trailingAnchor, constant: -20.0),
+        ])
+    }
+
+    @objc private func selectPreviousRow()
+    {
+        self.selectedRow = max(0, self.selectedRow - 1)
+        self.updateList()
+    }
+
+    @objc private func selectNextRow()
+    {
+        self.selectedRow = min(Self.rowCount - 1, self.selectedRow + 1)
+        self.updateList()
+    }
+
+    @objc private func toggleSelectedRowHeight()
+    {
+        if self.expandedRows.contains(self.selectedRow) {
+            self.expandedRows.remove(self.selectedRow)
+        } else {
+            self.expandedRows.insert(self.selectedRow)
+        }
+
+        self.updateList()
+    }
+
+    private func updateList()
+    {
+        self.footerTitle.text = "Target row \(self.selectedRow + 1) stays above the fixed footer"
+
+        let selectedRow = self.selectedRow
+        let targetIdentifier = FooterAwarePinnedItem.identifier(with: selectedRow)
+
+        self.list.configure { list in
+            list.appearance = .demoAppearance
+            list.layout = .demoLayout
+            list.animation = .fast
+            list.scrollIndicatorInsets.bottom = 112.0
+
+            list.autoScrollAction = .pin(
+                .item(targetIdentifier),
+                itemPosition: .verticalContentOffsetAdjustment { [weak self] info in
+                    self?.footerAwareScrollDelta(for: info) ?? 0.0
+                },
+                animated: false,
+                scrollInterruptionPolicy: .deferDuringUserScrolling,
+                shouldPerform: { _ in true }
+            )
+
+            list += Section("rows") {
+                for row in 0..<Self.rowCount {
+                    FooterAwarePinnedItem(
+                        row: row,
+                        isSelected: row == selectedRow,
+                        isExpanded: self.expandedRows.contains(row)
+                    )
+                }
+            }
+        }
+    }
+
+    private func footerAwareScrollDelta(for info: ListItemScrollPositionInfo) -> CGFloat
+    {
+        let topGap : CGFloat = 16.0
+        let footerGap : CGFloat = 16.0
+        let footerHeight = self.footer.bounds.height
+
+        let idealTop = info.visibleContentFrame.minY + topGap
+        let idealBottom = info.visibleContentFrame.maxY - footerHeight - footerGap
+
+        if info.itemFrame.height > idealBottom - idealTop {
+            return info.itemFrame.minY - idealTop
+        }
+
+        if info.itemFrame.minY < idealTop {
+            return info.itemFrame.minY - idealTop
+        }
+
+        if info.itemFrame.maxY > idealBottom {
+            return info.itemFrame.maxY - idealBottom
+        }
+
+        return 0.0
+    }
+
+    private static let rowCount = 50
+}
+
+
+private struct FooterAwarePinnedItem : BlueprintItemContent, Equatable
+{
+    var row : Int
+    var isSelected : Bool
+    var isExpanded : Bool
+
+    var identifierValue : Int {
+        self.row
+    }
+
+    func element(with info : ApplyItemContentInfo) -> Element
+    {
+        let title = Label(text: "Row \(self.row + 1)") {
+            $0.font = .systemFont(ofSize: 17.0, weight: self.isSelected ? .semibold : .regular)
+            $0.color = self.isSelected ? .systemBlue : .label
+        }
+
+        let detail = Label(text: self.detailText) {
+            $0.font = .systemFont(ofSize: 14.0, weight: .regular)
+            $0.color = .secondaryLabel
+        }
+
+        let content = Column(alignment: .fill, minimumSpacing: 6.0) {
+            title
+            detail
+        }
+
+        var box = Box(
+            backgroundColor: self.isSelected ? UIColor.systemBlue.withAlphaComponent(0.08) : .white,
+            cornerStyle: .rounded(radius: 6.0),
+            wrapping: Inset(
+                uniformInset: 14.0,
+                wrapping: content
+            )
+        )
+
+        box.borderStyle = .solid(
+            color: self.isSelected ? .systemBlue : .white(0.9),
+            width: 2.0
+        )
+
+        return box
+    }
+
+    private var detailText : String {
+        if self.isExpanded {
+            return "Expanded row content demonstrates a layout update that re-runs declarative custom auto-scroll."
+        } else if self.isSelected {
+            return "Selected target row"
+        } else {
+            return "Regular row"
+        }
+    }
+}

--- a/Development/Sources/Demos/DemosRootViewController.swift
+++ b/Development/Sources/Demos/DemosRootViewController.swift
@@ -81,6 +81,14 @@ public final class DemosRootViewController : ListViewController
                         self?.push(PinAutoscrollingViewController())
                     }
                 )
+
+                Item(
+                    DemoItem(text: "Custom Auto Scrolling (Footer-Aware Pin)"),
+                    selectionStyle: .selectable(),
+                    onSelect : { _ in
+                        self?.push(CustomAutoScrollingViewController())
+                    }
+                )
                 
                 Item(
                     DemoItem(text: "scrollTo(item: ...) completion handler"),
@@ -426,4 +434,3 @@ public final class DemosRootViewController : ListViewController
         }
     }
 }
-

--- a/ListableUI/Sources/AutoScrollAction.swift
+++ b/ListableUI/Sources/AutoScrollAction.swift
@@ -59,6 +59,30 @@ public enum AutoScrollAction {
         onInsertOf insertedIdentifier: AnyIdentifier,
         position: ScrollPosition,
         animated : Bool = false,
+        scrollInterruptionPolicy : ScrollInterruptionPolicy = .performImmediately,
+        shouldPerform : @escaping (ListScrollPositionInfo) -> Bool = { _ in true },
+        didPerform : @escaping (ListScrollPositionInfo) -> () = { _ in }
+    ) -> AutoScrollAction
+    {
+        self.scrollTo(
+            destination,
+            onInsertOf: insertedIdentifier,
+            itemPosition: .standard(position),
+            animated: animated,
+            scrollInterruptionPolicy: scrollInterruptionPolicy,
+            shouldPerform: shouldPerform,
+            didPerform: didPerform
+        )
+    }
+
+    /// Scrolls to the specified item when the list is updated if the item was inserted in this update,
+    /// using a custom item positioning strategy.
+    public static func scrollTo(
+        _ destination : ScrollDestination? = nil,
+        onInsertOf insertedIdentifier: AnyIdentifier,
+        itemPosition: ListItemScrollPosition,
+        animated : Bool = false,
+        scrollInterruptionPolicy : ScrollInterruptionPolicy = .performImmediately,
         shouldPerform : @escaping (ListScrollPositionInfo) -> Bool = { _ in true },
         didPerform : @escaping (ListScrollPositionInfo) -> () = { _ in }
     ) -> AutoScrollAction
@@ -67,7 +91,8 @@ public enum AutoScrollAction {
             onInsertOf: .init(
                 destination: destination ?? .item(insertedIdentifier),
                 insertedIdentifier: insertedIdentifier,
-                position: position,
+                itemPosition: itemPosition,
+                scrollInterruptionPolicy: scrollInterruptionPolicy,
                 animated: animated,
                 shouldPerform: shouldPerform,
                 didPerform: didPerform
@@ -110,6 +135,27 @@ public enum AutoScrollAction {
         _ destination : ScrollDestination,
         position: ScrollPosition,
         animated : Bool = false,
+        scrollInterruptionPolicy : ScrollInterruptionPolicy = .performImmediately,
+        shouldPerform : @escaping (ListScrollPositionInfo) -> Bool = { _ in true },
+        didPerform : @escaping (ListScrollPositionInfo) -> () = { _ in }
+    ) -> AutoScrollAction
+    {
+        self.pin(
+            destination,
+            itemPosition: .standard(position),
+            animated: animated,
+            scrollInterruptionPolicy: scrollInterruptionPolicy,
+            shouldPerform: shouldPerform,
+            didPerform: didPerform
+        )
+    }
+
+    /// Scrolls to the specified item when the list is updated using a custom item positioning strategy.
+    public static func pin(
+        _ destination : ScrollDestination,
+        itemPosition: ListItemScrollPosition,
+        animated : Bool = false,
+        scrollInterruptionPolicy : ScrollInterruptionPolicy = .performImmediately,
         shouldPerform : @escaping (ListScrollPositionInfo) -> Bool = { _ in true },
         didPerform : @escaping (ListScrollPositionInfo) -> () = { _ in }
     ) -> AutoScrollAction
@@ -117,7 +163,8 @@ public enum AutoScrollAction {
         .pin(
             to: .init(
                 destination: destination,
-                position: position,
+                itemPosition: itemPosition,
+                scrollInterruptionPolicy: scrollInterruptionPolicy,
                 animated: animated,
                 shouldPerform: shouldPerform,
                 didPerform: didPerform
@@ -129,6 +176,18 @@ public enum AutoScrollAction {
 
 extension AutoScrollAction
 {
+    /// Controls how an auto-scroll action behaves when user scrolling is active.
+    public enum ScrollInterruptionPolicy {
+        /// Perform the auto-scroll action as soon as the list updates.
+        case performImmediately
+
+        /// Wait until the current user scroll finishes before performing the auto-scroll action.
+        case deferDuringUserScrolling
+
+        /// Do not perform the auto-scroll action while the user is scrolling.
+        case skipDuringUserScrolling
+    }
+
     /// Where to scroll as a result of an `AutoScrollAction`.
     public enum ScrollDestination : Equatable
     {
@@ -182,8 +241,24 @@ extension AutoScrollAction
         
         /// The identifier of the item for which the `AutoScrollAction` should be performed.
         public var insertedIdentifier : AnyIdentifier
-        
-        public var position : ScrollPosition
+
+        public var itemPosition : ListItemScrollPosition
+
+        public var position : ScrollPosition {
+            get {
+                switch self.itemPosition.storage {
+                case .standard(let position):
+                    return position
+                case .verticalContentOffsetAdjustment:
+                    return ScrollPosition(position: .bottom)
+                }
+            }
+            set {
+                self.itemPosition = .standard(newValue)
+            }
+        }
+
+        public var scrollInterruptionPolicy : ScrollInterruptionPolicy
         
         public var animated : Bool
         
@@ -197,7 +272,23 @@ extension AutoScrollAction
     {
         public var destination : ScrollDestination
 
-        public var position : ScrollPosition
+        public var itemPosition : ListItemScrollPosition
+
+        public var position : ScrollPosition {
+            get {
+                switch self.itemPosition.storage {
+                case .standard(let position):
+                    return position
+                case .verticalContentOffsetAdjustment:
+                    return ScrollPosition(position: .bottom)
+                }
+            }
+            set {
+                self.itemPosition = .standard(newValue)
+            }
+        }
+
+        public var scrollInterruptionPolicy : ScrollInterruptionPolicy
         
         public var animated : Bool
         
@@ -206,3 +297,11 @@ extension AutoScrollAction
         public var didPerform : (ListScrollPositionInfo) -> ()
     }
 }
+
+protocol _AutoScrollActionConfiguration: AutoScrollAction.Configuration {
+    var itemPosition : ListItemScrollPosition { get set }
+    var scrollInterruptionPolicy : AutoScrollAction.ScrollInterruptionPolicy { get set }
+}
+
+extension AutoScrollAction.OnInsertedItem: _AutoScrollActionConfiguration {}
+extension AutoScrollAction.Pin: _AutoScrollActionConfiguration {}

--- a/ListableUI/Sources/ListActions.swift
+++ b/ListableUI/Sources/ListActions.swift
@@ -109,6 +109,28 @@ public final class ListActions {
                 completion: completion
             )
         }
+
+        ///
+        /// Scrolls to a custom vertical offset for the provided item.
+        /// The adjustment receives the item's frame and visible content frame,
+        /// then returns the vertical delta to apply.
+        /// If the item is contained in the list, true is returned. If it is not, false is returned.
+        ///
+        @discardableResult
+        public func scrollTo(
+            item : AnyItem,
+            contentOffsetAdjustment : @escaping ListItemScrollPositionAdjustment,
+            animated : Bool = false,
+            completion: ScrollCompletion? = nil
+        ) -> Bool
+        {
+            self.scrollTo(
+                item: item.anyIdentifier,
+                contentOffsetAdjustment: contentOffsetAdjustment,
+                animated: animated,
+                completion: completion
+            )
+        }
         
         ///
         /// Scrolls to the item with the provided identifier, with the provided positioning.
@@ -130,6 +152,33 @@ public final class ListActions {
             return listView.scrollTo(
                 item: item,
                 position: position,
+                animated: animated,
+                completion: completion
+            )
+        }
+
+        ///
+        /// Scrolls to a custom vertical offset for the item with the provided identifier.
+        /// The adjustment receives the item's frame and visible content frame,
+        /// then returns the vertical delta to apply.
+        /// If there is more than one item with the same identifier, the list scrolls to the first.
+        /// If the item is contained in the list, true is returned. If it is not, false is returned.
+        ///
+        @discardableResult
+        public func scrollTo(
+            item : AnyIdentifier,
+            contentOffsetAdjustment : @escaping ListItemScrollPositionAdjustment,
+            animated : Bool = false,
+            completion: ScrollCompletion? = nil
+            ) -> Bool
+        {
+            guard let listView = self.listView else {
+                return false
+            }
+
+            return listView.scrollTo(
+                item: item,
+                contentOffsetAdjustment: contentOffsetAdjustment,
                 animated: animated,
                 completion: completion
             )

--- a/ListableUI/Sources/ListItemScrollPositionInfo.swift
+++ b/ListableUI/Sources/ListItemScrollPositionInfo.swift
@@ -12,6 +12,29 @@ import UIKit
 /// Returns the vertical delta to apply to the list's current content offset.
 public typealias ListItemScrollPositionAdjustment = (ListItemScrollPositionInfo) -> CGFloat
 
+/// Specifies how to position an item in a list when requesting the list scrolls to it.
+public struct ListItemScrollPosition {
+
+    enum Storage {
+        case standard(ScrollPosition)
+        case verticalContentOffsetAdjustment(ListItemScrollPositionAdjustment)
+    }
+
+    let storage: Storage
+
+    /// Positions the item using Listable's standard item scroll positioning.
+    public static func standard(_ position: ScrollPosition) -> ListItemScrollPosition {
+        ListItemScrollPosition(storage: .standard(position))
+    }
+
+    /// Positions the item by applying a custom vertical delta to the current content offset.
+    public static func verticalContentOffsetAdjustment(
+        _ adjustment: @escaping ListItemScrollPositionAdjustment
+    ) -> ListItemScrollPosition {
+        ListItemScrollPosition(storage: .verticalContentOffsetAdjustment(adjustment))
+    }
+}
+
 /// Information available when calculating a custom scroll adjustment for an item.
 public struct ListItemScrollPositionInfo: Equatable {
 
@@ -23,4 +46,14 @@ public struct ListItemScrollPositionInfo: Equatable {
 
     /// The current scroll position of the list.
     public let positionInfo: ListScrollPositionInfo
+
+    public init(
+        itemFrame: CGRect,
+        visibleContentFrame: CGRect,
+        positionInfo: ListScrollPositionInfo
+    ) {
+        self.itemFrame = itemFrame
+        self.visibleContentFrame = visibleContentFrame
+        self.positionInfo = positionInfo
+    }
 }

--- a/ListableUI/Sources/ListItemScrollPositionInfo.swift
+++ b/ListableUI/Sources/ListItemScrollPositionInfo.swift
@@ -10,6 +10,10 @@ import UIKit
 
 
 /// Returns the vertical delta to apply to the list's current content offset.
+///
+/// When this adjustment is stored on an auto-scroll action, avoid strongly capturing
+/// an object that owns or configures the list. Capture that object weakly to prevent
+/// retain cycles.
 public typealias ListItemScrollPositionAdjustment = (ListItemScrollPositionInfo) -> CGFloat
 
 /// Specifies how to position an item in a list when requesting the list scrolls to it.
@@ -28,6 +32,9 @@ public struct ListItemScrollPosition {
     }
 
     /// Positions the item by applying a custom vertical delta to the current content offset.
+    ///
+    /// The adjustment may be stored by declarative scrolling APIs. If it captures an object
+    /// that owns or configures the list, capture that object weakly to prevent retain cycles.
     public static func verticalContentOffsetAdjustment(
         _ adjustment: @escaping ListItemScrollPositionAdjustment
     ) -> ListItemScrollPosition {

--- a/ListableUI/Sources/ListItemScrollPositionInfo.swift
+++ b/ListableUI/Sources/ListItemScrollPositionInfo.swift
@@ -1,0 +1,26 @@
+//
+//  ListItemScrollPositionInfo.swift
+//  ListableUI
+//
+//  Created by Square on 5/21/26.
+//
+
+import Foundation
+import UIKit
+
+
+/// Returns the vertical delta to apply to the list's current content offset.
+public typealias ListItemScrollPositionAdjustment = (ListItemScrollPositionInfo) -> CGFloat
+
+/// Information available when calculating a custom scroll adjustment for an item.
+public struct ListItemScrollPositionInfo: Equatable {
+
+    /// The item's frame in the list content coordinate space.
+    public let itemFrame: CGRect
+
+    /// The visible content frame in the list content coordinate space.
+    public let visibleContentFrame: CGRect
+
+    /// The current scroll position of the list.
+    public let positionInfo: ListScrollPositionInfo
+}

--- a/ListableUI/Sources/ListScrollPositionInfo.swift
+++ b/ListableUI/Sources/ListScrollPositionInfo.swift
@@ -47,6 +47,9 @@ public struct ListScrollPositionInfo : Equatable {
 
     /// `safeAreaInsests` of the list view
     public var safeAreaInsets: UIEdgeInsets
+
+    /// Whether the scroll view is currently being interacted with or decelerating.
+    public var isScrollInProgress: Bool
     
     ///
     /// Used to retrieve the visible content edges for the list's content.
@@ -129,6 +132,7 @@ public struct ListScrollPositionInfo : Equatable {
 
         self.bounds = scrollView.bounds
         self.safeAreaInsets = scrollView.safeAreaInsets
+        self.isScrollInProgress = scrollView.isTracking || scrollView.isDragging || scrollView.isDecelerating
     }
     
     struct ScrollViewState : Equatable

--- a/ListableUI/Sources/ListStateObserver.swift
+++ b/ListableUI/Sources/ListStateObserver.swift
@@ -228,11 +228,13 @@ extension ListStateObserver
     
     /// Parameters available for ``OnDidEndDeceleration`` callbacks.
     public struct DidEndDeceleration {
+        public let actions : ListActions
         public let positionInfo : ListScrollPositionInfo
     }
 
     /// Parameters available for ``OnDidEndScrollingAnimation`` callbacks.
     public struct DidEndScrollingAnimation {
+        public let actions : ListActions
         public let positionInfo : ListScrollPositionInfo
     }
 

--- a/ListableUI/Sources/ListView/ListView.Delegate.swift
+++ b/ListableUI/Sources/ListView/ListView.Delegate.swift
@@ -100,8 +100,9 @@ extension ListView
 
         func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView)
         {
-            ListStateObserver.perform(self.view.stateObserver.onDidEndScrollingAnimation, "Did End Scrolling Animation", with: self.view) { _ in
+            ListStateObserver.perform(self.view.stateObserver.onDidEndScrollingAnimation, "Did End Scrolling Animation", with: self.view) { actions in
                 ListStateObserver.DidEndScrollingAnimation(
+                    actions: actions,
                     positionInfo: self.view.scrollPositionInfo
                 )
             }
@@ -341,8 +342,9 @@ extension ListView
         {
             self.view.updatePresentationState(for: .didEndDecelerating)
             
-            ListStateObserver.perform(self.view.stateObserver.onDidEndDeceleration, "Did End Deceleration", with: self.view) { _ in
+            ListStateObserver.perform(self.view.stateObserver.onDidEndDeceleration, "Did End Deceleration", with: self.view) { actions in
                 ListStateObserver.DidEndDeceleration(
+                    actions: actions,
                     positionInfo: self.view.scrollPositionInfo
                 )
             }

--- a/ListableUI/Sources/ListView/ListView.Delegate.swift
+++ b/ListableUI/Sources/ListView/ListView.Delegate.swift
@@ -100,6 +100,8 @@ extension ListView
 
         func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView)
         {
+            let scrollCompletions = self.view.drainScrollCompletionHandlers()
+
             ListStateObserver.perform(self.view.stateObserver.onDidEndScrollingAnimation, "Did End Scrolling Animation", with: self.view) { actions in
                 ListStateObserver.DidEndScrollingAnimation(
                     actions: actions,
@@ -108,7 +110,7 @@ extension ListView
             }
             
             // Notify the ListView that scrolling ended.
-            self.view.didEndScrolling()
+            self.view.performScrollCompletions(scrollCompletions)
         }
 
         private var oldSelectedItems : Set<AnyIdentifier> = []

--- a/ListableUI/Sources/ListView/ListView.Delegate.swift
+++ b/ListableUI/Sources/ListView/ListView.Delegate.swift
@@ -327,6 +327,8 @@ extension ListView
         
         func scrollViewWillBeginDragging(_ scrollView: UIScrollView)
         {
+            self.view.isUserScrollInProgress = true
+
             self.view.liveCells.perform {
                 $0.closeSwipeActions()
             }
@@ -337,9 +339,20 @@ extension ListView
                 )
             }
         }
+
+        func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool)
+        {
+            guard decelerate == false else {
+                return
+            }
+
+            self.view.isUserScrollInProgress = false
+            self.view.flushPendingAutoScrollAction()
+        }
         
         func scrollViewDidEndDecelerating(_ scrollView: UIScrollView)
         {
+            self.view.isUserScrollInProgress = false
             self.view.updatePresentationState(for: .didEndDecelerating)
             
             ListStateObserver.perform(self.view.stateObserver.onDidEndDeceleration, "Did End Deceleration", with: self.view) { actions in
@@ -348,6 +361,8 @@ extension ListView
                     positionInfo: self.view.scrollPositionInfo
                 )
             }
+
+            self.view.flushPendingAutoScrollAction()
         }
                 
         func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -544,6 +544,28 @@ public final class ListView : UIView
             completion: completion
         )
     }
+
+    ///
+    /// Scrolls to a custom vertical offset for the provided item.
+    /// The adjustment receives the item's frame and visible content frame,
+    /// then returns the vertical delta to apply.
+    /// If the item is contained in the list, true is returned. If it is not, false is returned.
+    ///
+    @discardableResult
+    public func scrollTo(
+        item : AnyItem,
+        contentOffsetAdjustment : @escaping ListItemScrollPositionAdjustment,
+        animated : Bool = false,
+        completion: ScrollCompletion? = nil
+    ) -> Bool
+    {
+        self.scrollTo(
+            item: item.anyIdentifier,
+            contentOffsetAdjustment: contentOffsetAdjustment,
+            animated: animated,
+            completion: completion
+        )
+    }
         
     ///
     /// Scrolls to the item with the provided identifier, with the provided positioning.
@@ -632,6 +654,60 @@ public final class ListView : UIView
                     }
                 }
             }
+        }
+    }
+
+    ///
+    /// Scrolls to a custom vertical offset for the item with the provided identifier.
+    /// The adjustment receives the item's frame and visible content frame,
+    /// then returns the vertical delta to apply.
+    /// If there is more than one item with the same identifier, the list scrolls to the first.
+    /// If the item is contained in the list, true is returned. If it is not, false is returned.
+    ///
+    @discardableResult
+    public func scrollTo(
+        item : AnyIdentifier,
+        contentOffsetAdjustment : @escaping ListItemScrollPositionAdjustment,
+        animated : Bool = false,
+        completion: ScrollCompletion? = nil
+    ) -> Bool
+    {
+        // Make sure the item identifier is valid.
+
+        guard let toIndexPath = self.storage.allContent.firstIndexPathForItem(with: item) else {
+            handleScrollCompletion(reason: .cannotScroll, completion: completion)
+            return false
+        }
+
+        // If user is performing this in a `UIView.performWithoutAnimation` block, respect that and don't animate, regardless of what the animated parameter is.
+        let shouldAnimate = animated && UIView.areAnimationsEnabled
+
+        return preparePresentationStateForScroll(to: toIndexPath, handlerWhenFailed: completion) {
+
+            /// `preparePresentationStateForScroll(to:)` is asynchronous in some
+            /// cases, we need to re-query the item index path in case it changed or is no longer valid.
+
+            guard let toIndexPath = self.storage.allContent.firstIndexPathForItem(with: item) else {
+                self.handleScrollCompletion(reason: .cannotScroll, completion: completion)
+                return
+            }
+
+            let itemFrame = self.collectionViewLayout.frameForItem(at: toIndexPath)
+            let visibleContentFrame = self.collectionView.visibleContentFrame
+            let positionInfo = ListItemScrollPositionInfo(
+                itemFrame: itemFrame,
+                visibleContentFrame: visibleContentFrame,
+                positionInfo: self.scrollPositionInfo
+            )
+
+            var resultOffset = self.collectionView.contentOffset
+            resultOffset.y += contentOffsetAdjustment(positionInfo)
+
+            self.performScroll(
+                toContentOffset: resultOffset,
+                animated: shouldAnimate,
+                completion: completion
+            )
         }
     }
 
@@ -807,7 +883,7 @@ public final class ListView : UIView
             // Dispatch so that the completion handler executes on the next runloop
             // execution.
             DispatchQueue.main.async {
-                completion(ListStateObserver.DidEndScrollingAnimation(positionInfo: self.scrollPositionInfo))
+                self.performScrollCompletion(completion, positionInfo: self.scrollPositionInfo)
             }
         case .scrolled(let animated):
             if animated {
@@ -818,10 +894,17 @@ public final class ListView : UIView
                 DispatchQueue.main.async {
                     // Sync the `scrollPositionInfo` before executing the handler.
                     self.performEmptyBatchUpdates()
-                    completion(ListStateObserver.DidEndScrollingAnimation(positionInfo: self.scrollPositionInfo))
+                    self.performScrollCompletion(completion, positionInfo: self.scrollPositionInfo)
                 }
             }
         }
+    }
+
+    private func performScrollCompletion(_ completion: ScrollCompletion, positionInfo: ListScrollPositionInfo) {
+        let actions = ListActions()
+        actions.listView = self
+        completion(ListStateObserver.DidEndScrollingAnimation(actions: actions, positionInfo: positionInfo))
+        actions.listView = nil
     }
     
     /// This is used to house the completion handlers of scrolling APIs. This is kept
@@ -852,7 +935,7 @@ public final class ListView : UIView
         performEmptyBatchUpdates()
         let positionInfo = scrollPositionInfo
         handlers.forEach { handler in
-            handler(ListStateObserver.DidEndScrollingAnimation(positionInfo: positionInfo))
+            performScrollCompletion(handler, positionInfo: positionInfo)
         }
     }
     
@@ -1569,6 +1652,46 @@ public final class ListView : UIView
         } else {
             handleScrollCompletion(reason: .cannotScroll, completion: completion)
         }
+    }
+
+    private func performScroll(
+        toContentOffset contentOffset : CGPoint,
+        animated: Bool = false,
+        completion: ScrollCompletion? = nil
+    ) {
+        let resultOffset = clampedContentOffset(contentOffset)
+
+        let roundedResultOffset = CGPoint(
+            x: round(resultOffset.x),
+            y: round(resultOffset.y)
+        )
+        let roundedCurrentOffset = CGPoint(
+            x: round(collectionView.contentOffset.x),
+            y: round(collectionView.contentOffset.y)
+        )
+        if roundedCurrentOffset != roundedResultOffset {
+            collectionView.setContentOffset(resultOffset, animated: animated)
+            handleScrollCompletion(reason: .scrolled(animated: animated), completion: completion)
+        } else {
+            handleScrollCompletion(reason: .cannotScroll, completion: completion)
+        }
+    }
+
+    private func clampedContentOffset(_ contentOffset : CGPoint) -> CGPoint {
+        var resultOffset = contentOffset
+
+        // Don't scroll past the bottom of the list.
+
+        let topInset = collectionView.adjustedContentInset.top
+        let contentFrameHeight = collectionView.visibleContentFrame.height
+        let maxOffsetHeight = collectionViewLayout.collectionViewContentSize.height - contentFrameHeight - topInset
+        resultOffset.y = min(resultOffset.y, maxOffsetHeight)
+
+        // Don't scroll beyond the top of the list.
+
+        resultOffset.y = max(resultOffset.y, -topInset)
+
+        return resultOffset
     }
 
     private func preparePresentationStateForScroll(to toIndexPath: IndexPath, handlerWhenFailed: ScrollCompletion?, scroll: @escaping () -> Void) -> Bool {

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -1665,7 +1665,7 @@ public final class ListView : UIView
             return false
         }
 
-        return self.isUserScrollInProgress || self.scrollPositionInfo.isScrollInProgress
+        return self.isUserScrollInProgress
     }
 
     private func shouldDeferAutoScroll(_ info: _AutoScrollActionConfiguration) -> Bool {
@@ -1673,7 +1673,7 @@ public final class ListView : UIView
             return false
         }
 
-        return self.isUserScrollInProgress || self.scrollPositionInfo.isScrollInProgress
+        return self.isUserScrollInProgress
     }
 
     internal func flushPendingAutoScrollAction() {

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -914,13 +914,21 @@ public final class ListView : UIView
     /// This is used to house the completion handlers of scrolling APIs. This is kept
     /// internal and separate from `ListStateObserver` and its handlers.
     internal var scrollCompletionHandlers: [ScrollCompletion] = []
+
+    internal struct ScrollCompletionBatch {
+        let handlers: [ScrollCompletion]
+        let positionInfo: ListScrollPositionInfo
+    }
     
     /// This is called by the `ListView.Delegate` and is used to notify the
     /// `scrollCompletionHandler` that scrolling finished. This does nothing if there is
     /// no handler set.
     internal func didEndScrolling() {
-        
-        guard scrollCompletionHandlers.isEmpty == false else { return }
+        self.performScrollCompletions(self.drainScrollCompletionHandlers())
+    }
+
+    internal func drainScrollCompletionHandlers() -> ScrollCompletionBatch? {
+        guard scrollCompletionHandlers.isEmpty == false else { return nil }
         let handlers = scrollCompletionHandlers
         
         // Proactively remove these handlers before executing them. This avoids a
@@ -938,8 +946,17 @@ public final class ListView : UIView
         // ListViewTests has unit tests to assert that the handler's items are correct.
         performEmptyBatchUpdates()
         let positionInfo = scrollPositionInfo
-        handlers.forEach { handler in
-            performScrollCompletion(handler, positionInfo: positionInfo)
+
+        return ScrollCompletionBatch(handlers: handlers, positionInfo: positionInfo)
+    }
+
+    internal func performScrollCompletions(_ batch: ScrollCompletionBatch?) {
+        guard let batch else {
+            return
+        }
+
+        batch.handlers.forEach { handler in
+            performScrollCompletion(handler, positionInfo: batch.positionInfo)
         }
     }
     

--- a/ListableUI/Sources/ListView/ListView.swift
+++ b/ListableUI/Sources/ListView/ListView.swift
@@ -185,6 +185,10 @@ public final class ListView : UIView
     private var sourcePresenter : AnySourcePresenter
 
     private var autoScrollAction : AutoScrollAction
+
+    private var pendingAutoScrollAction : PendingAutoScrollAction?
+
+    var isUserScrollInProgress = false
     
     private let dataSource : DataSource
     
@@ -1536,6 +1540,11 @@ public final class ListView : UIView
         }
     }
 
+    private struct PendingAutoScrollAction {
+        var addedItems : Set<AnyIdentifier>
+        var animated : Bool
+    }
+
     private func performAutoScrollAction(with addedItems : Set<AnyIdentifier>, animated : Bool)
     {
         switch self.autoScrollAction {
@@ -1551,49 +1560,139 @@ public final class ListView : UIView
             autoScroll(with: pin)
         }
         
-        func autoScroll(with info: AutoScrollAction.Configuration) {
-            if info.shouldPerform(self.scrollPositionInfo) {
-                
-                /// Only animate the scroll if both the update **and** the scroll action are animated.
-                let animated = info.animated && animated
-                
-                if let destination = info.destination.destination(with: self.content) {
-                    
-                    if behavior.verticalLayoutGravity == .bottom {
-                        /// Temporarily ignore the bottom gravity offest overrides before scrolling. This
-                        /// avoids an issue where:
-                        ///   - the list has `VerticalLayoutGravity.bottom` and `AutoScrollAction` behaviors
-                        ///   - the list has offscreen items that haven't been sized
-                        ///   - the `AutoScrollAction` has been triggered
-                        ///   - the resulting scroll position will adjust the collection view's `contentSize`
-                        ///     as items are dequeued and sized
-                        ///
-                        /// Without ignoring the custom `VerticalLayoutGravity.bottom` offset behavior, the
-                        /// above scenario will force the scroll offset to the bottom, discarding this scroll
-                        /// update.
-                        collectionView.ignoreBottomGravityOffsetOverride = true
-                    }
-                    
-                    guard self.scrollTo(item: destination, position: info.position, animated: animated) else {
-                        collectionView.ignoreBottomGravityOffsetOverride = false
-                        return
-                    }
-                    if animated {
-                        stateObserver.onDidEndScrollingAnimation { [weak self] state in
-                            self?.collectionView.ignoreBottomGravityOffsetOverride = false
-                            info.didPerform(state.positionInfo)
-                        }
-                    } else {
-                        /// Perform an update after an animationless scroll so that `CollectionViewLayout`'s
-                        /// `prepare()` function will synchronously execute before calling `didPerform`. Otherwise,
-                        /// the list's `visibleContent` and the resulting `scrollPositionInfo.visibleItems` will
-                        /// be stale.
-                        performEmptyBatchUpdates()
-                        collectionView.ignoreBottomGravityOffsetOverride = false
-                        info.didPerform(scrollPositionInfo)
-                    }
-                }
+        func autoScroll(with info: _AutoScrollActionConfiguration) {
+            if self.shouldSkipAutoScroll(info) {
+                return
             }
+
+            if self.shouldDeferAutoScroll(info) {
+                self.pendingAutoScrollAction = PendingAutoScrollAction(
+                    addedItems: addedItems,
+                    animated: animated
+                )
+                return
+            }
+
+            guard info.shouldPerform(self.scrollPositionInfo) else {
+                return
+            }
+
+            /// Only animate the scroll if both the update **and** the scroll action are animated.
+            let shouldAnimate = info.animated && animated
+
+            guard let destination = info.destination.destination(with: self.content) else {
+                return
+            }
+
+            if behavior.verticalLayoutGravity == .bottom {
+                /// Temporarily ignore the bottom gravity offest overrides before scrolling. This
+                /// avoids an issue where:
+                ///   - the list has `VerticalLayoutGravity.bottom` and `AutoScrollAction` behaviors
+                ///   - the list has offscreen items that haven't been sized
+                ///   - the `AutoScrollAction` has been triggered
+                ///   - the resulting scroll position will adjust the collection view's `contentSize`
+                ///     as items are dequeued and sized
+                ///
+                /// Without ignoring the custom `VerticalLayoutGravity.bottom` offset behavior, the
+                /// above scenario will force the scroll offset to the bottom, discarding this scroll
+                /// update.
+                collectionView.ignoreBottomGravityOffsetOverride = true
+            }
+
+            var didBeginScroll = false
+            let completion : ScrollCompletion = { [weak self] _ in
+                guard didBeginScroll else {
+                    return
+                }
+
+                guard let self else {
+                    return
+                }
+
+                self.performEmptyBatchUpdates()
+                self.collectionView.ignoreBottomGravityOffsetOverride = false
+                info.didPerform(self.scrollPositionInfo)
+            }
+
+            switch info.itemPosition.storage {
+            case .standard where shouldAnimate == false:
+                didBeginScroll = self.scrollTo(
+                    item: destination,
+                    itemPosition: info.itemPosition,
+                    animated: false,
+                    completion: nil
+                )
+
+                if didBeginScroll {
+                    performEmptyBatchUpdates()
+                    collectionView.ignoreBottomGravityOffsetOverride = false
+                    info.didPerform(scrollPositionInfo)
+                }
+            case .standard, .verticalContentOffsetAdjustment:
+                didBeginScroll = self.scrollTo(
+                    item: destination,
+                    itemPosition: info.itemPosition,
+                    animated: shouldAnimate,
+                    completion: completion
+                )
+            }
+
+            if didBeginScroll == false {
+                collectionView.ignoreBottomGravityOffsetOverride = false
+            }
+        }
+    }
+
+    private func shouldSkipAutoScroll(_ info: _AutoScrollActionConfiguration) -> Bool {
+        guard info.scrollInterruptionPolicy == .skipDuringUserScrolling else {
+            return false
+        }
+
+        return self.isUserScrollInProgress || self.scrollPositionInfo.isScrollInProgress
+    }
+
+    private func shouldDeferAutoScroll(_ info: _AutoScrollActionConfiguration) -> Bool {
+        guard info.scrollInterruptionPolicy == .deferDuringUserScrolling else {
+            return false
+        }
+
+        return self.isUserScrollInProgress || self.scrollPositionInfo.isScrollInProgress
+    }
+
+    internal func flushPendingAutoScrollAction() {
+        guard let pendingAutoScrollAction else {
+            return
+        }
+
+        self.pendingAutoScrollAction = nil
+        self.performAutoScrollAction(
+            with: pendingAutoScrollAction.addedItems,
+            animated: pendingAutoScrollAction.animated
+        )
+    }
+
+    @discardableResult
+    private func scrollTo(
+        item : AnyIdentifier,
+        itemPosition : ListItemScrollPosition,
+        animated : Bool = false,
+        completion: ScrollCompletion? = nil
+    ) -> Bool {
+        switch itemPosition.storage {
+        case .standard(let position):
+            return self.scrollTo(
+                item: item,
+                position: position,
+                animated: animated,
+                completion: completion
+            )
+        case .verticalContentOffsetAdjustment(let adjustment):
+            return self.scrollTo(
+                item: item,
+                contentOffsetAdjustment: adjustment,
+                animated: animated,
+                completion: completion
+            )
         }
     }
 

--- a/ListableUI/Tests/ListScrollPositionInfoTests.swift
+++ b/ListableUI/Tests/ListScrollPositionInfoTests.swift
@@ -71,8 +71,54 @@ final class UIRectEdgeTests : XCTestCase
         XCTAssertEqual(info.mostVisibleItem?.identifier.anyValue, 2)
         XCTAssertEqual(info.mostVisibleItem?.percentageVisible, 1.0)
     }
+
+    func test_isScrollInProgress() {
+
+        let scrollView = ScrollView()
+
+        func makeInfo() -> ListScrollPositionInfo {
+            ListScrollPositionInfo(
+                scrollView: scrollView,
+                visibleItems: [],
+                isFirstItemVisible: true,
+                isLastItemVisible: false
+            )
+        }
+
+        XCTAssertFalse(makeInfo().isScrollInProgress)
+
+        scrollView.isTrackingValue = true
+        XCTAssertTrue(makeInfo().isScrollInProgress)
+
+        scrollView.isTrackingValue = false
+        scrollView.isDraggingValue = true
+        XCTAssertTrue(makeInfo().isScrollInProgress)
+
+        scrollView.isDraggingValue = false
+        scrollView.isDeceleratingValue = true
+        XCTAssertTrue(makeInfo().isScrollInProgress)
+    }
     
     fileprivate struct TestingType { }
+
+    private final class ScrollView : UIScrollView {
+
+        var isTrackingValue = false
+        var isDraggingValue = false
+        var isDeceleratingValue = false
+
+        override var isTracking : Bool {
+            isTrackingValue
+        }
+
+        override var isDragging : Bool {
+            isDraggingValue
+        }
+
+        override var isDecelerating : Bool {
+            isDeceleratingValue
+        }
+    }
 }
 
 final class UIEdgeInsetsTests : XCTestCase

--- a/ListableUI/Tests/ListView/ListViewTests.swift
+++ b/ListableUI/Tests/ListView/ListViewTests.swift
@@ -653,7 +653,7 @@ class ListViewTests: XCTestCase
                     TestContent(content: "A")
                 }
                 vc.list.configure(with: content)
-                waitFor { vc.list.updateQueue.isEmpty }
+                waitFor { didPerform.count == 1 }
                 XCTAssertEqual(didPerform.count, 1)
                 
                 guard let visibleItems = didPerform.first?.visibleItems else {
@@ -731,7 +731,7 @@ class ListViewTests: XCTestCase
                 )
                 
                 vc.list.configure(with: content)
-                waitFor { vc.list.updateQueue.isEmpty }
+                waitFor { didPerform.count == 1 }
                 XCTAssertEqual(didPerform.count, 1)
                 
                 guard let visibleItems = didPerform.first?.visibleItems else {
@@ -812,7 +812,7 @@ class ListViewTests: XCTestCase
                     TestContent(content: "A")
                 }
                 vc.list.configure(with: content)
-                waitFor { vc.list.updateQueue.isEmpty }
+                waitFor { didPerform.count == 1 }
                 XCTAssertEqual(didPerform.count, 1)
                 
                 guard let visibleItems = didPerform.first?.visibleItems else {
@@ -842,6 +842,354 @@ class ListViewTests: XCTestCase
                             percentageVisible: 1.0
                         )
                     )
+                )
+            }
+        }
+    }
+
+    func test_auto_scroll_action_with_vertical_content_offset_adjustment() throws {
+
+        try self.testcase("pin applies custom offset") {
+            var capturedInfo: ListItemScrollPositionInfo?
+            var offsetAtAdjustment: CGFloat?
+            var didPerform: [ListScrollPositionInfo] = []
+
+            let vc = ViewController()
+            vc.listFramingBehavior = .exactly(CGSize(width: 400, height: 600))
+
+            let content = makeAutoScrollContent(
+                target: TestContent.Identifier("Item 75"),
+                itemPosition: .verticalContentOffsetAdjustment { info in
+                    capturedInfo = info
+                    offsetAtAdjustment = vc.list.collectionView.contentOffset.y
+                    return 125.0
+                },
+                didPerform: { didPerform.append($0) }
+            )
+
+            try show(vc: vc) { vc in
+                vc.list.configure(with: content)
+                waitFor { didPerform.count == 1 }
+
+                let itemIndexPath = try XCTUnwrap(
+                    vc.list.storage.allContent.firstIndexPathForItem(with: TestContent.Identifier("Item 75"))
+                )
+                let info = try XCTUnwrap(capturedInfo)
+                XCTAssertEqual(
+                    vc.list.collectionView.contentOffset.y,
+                    try XCTUnwrap(offsetAtAdjustment) + 125.0,
+                    accuracy: 0.1
+                )
+                XCTAssertEqual(info.itemFrame, vc.list.collectionViewLayout.frameForItem(at: itemIndexPath))
+                XCTAssertEqual(info.visibleContentFrame.origin.y, 0.0, accuracy: 0.1)
+                XCTAssertEqual(info.positionInfo.isScrollInProgress, false)
+            }
+        }
+
+        self.testcase("pin clamps custom offset") {
+            var didPerform: [ListScrollPositionInfo] = []
+
+            let vc = ViewController()
+            vc.listFramingBehavior = .exactly(CGSize(width: 400, height: 600))
+
+            show(vc: vc) { vc in
+                vc.list.configure(with: makeAutoScrollContent(
+                    target: TestContent.Identifier("Item 75"),
+                    itemPosition: .verticalContentOffsetAdjustment { _ in 100_000.0 },
+                    didPerform: { didPerform.append($0) }
+                ))
+                waitFor { didPerform.count == 1 }
+
+                XCTAssertEqual(
+                    vc.list.collectionView.bounds.maxY,
+                    vc.list.collectionView.contentSize.height + vc.list.collectionView.adjustedContentInset.bottom,
+                    accuracy: 0.1
+                )
+
+                vc.list.configure(with: makeAutoScrollContent(
+                    target: TestContent.Identifier("Item 1"),
+                    itemPosition: .verticalContentOffsetAdjustment { _ in -100_000.0 },
+                    didPerform: { didPerform.append($0) }
+                ))
+                waitFor { didPerform.count == 2 }
+
+                XCTAssertEqual(
+                    vc.list.collectionView.contentOffset.y,
+                    -vc.list.collectionView.adjustedContentInset.top,
+                    accuracy: 0.1
+                )
+            }
+        }
+
+        for animated in [true, false] {
+            self.testcase("pin runs didPerform once animated: \(animated)") {
+                var didPerform: [ListScrollPositionInfo] = []
+
+                let content = makeAutoScrollContent(
+                    target: TestContent.Identifier("Item 75"),
+                    itemPosition: .verticalContentOffsetAdjustment { _ in 125.0 },
+                    animated: animated,
+                    didPerform: { didPerform.append($0) }
+                )
+
+                let vc = ViewController()
+                vc.listFramingBehavior = .exactly(CGSize(width: 400, height: 600))
+
+                show(vc: vc) { vc in
+                    vc.list.configure(with: content)
+                    waitFor { didPerform.count == 1 }
+                    XCTAssertEqual(didPerform.count, 1)
+                }
+            }
+        }
+
+        try self.testcase("scroll to inserted item uses custom offset") {
+            var didPerform: [ListScrollPositionInfo] = []
+            var capturedInfo: ListItemScrollPositionInfo?
+
+            let insertedID = TestContent.Identifier("A")
+            let vc = ViewController()
+            vc.listFramingBehavior = .exactly(CGSize(width: 400, height: 600))
+
+            var offsetAtAdjustment: CGFloat?
+            var content = makeInsertedAutoScrollContent(
+                insertedID: insertedID,
+                itemPosition: .verticalContentOffsetAdjustment { info in
+                    capturedInfo = info
+                    offsetAtAdjustment = vc.list.collectionView.contentOffset.y
+                    return 125.0
+                },
+                didPerform: { didPerform.append($0) }
+            )
+
+            try show(vc: vc) { vc in
+                vc.list.configure(with: content)
+                waitFor { vc.list.updateQueue.isEmpty }
+                XCTAssertEqual(didPerform.count, 0)
+
+                content.content += Section("new") {
+                    TestContent(content: "A")
+                }
+                vc.list.configure(with: content)
+                waitFor { didPerform.count == 1 }
+
+                let info = try XCTUnwrap(capturedInfo)
+                XCTAssertEqual(
+                    vc.list.collectionView.contentOffset.y,
+                    try XCTUnwrap(offsetAtAdjustment) + 125.0,
+                    accuracy: 0.1
+                )
+                XCTAssertEqual(info.positionInfo.isScrollInProgress, false)
+            }
+        }
+
+        func makeAutoScrollContent(
+            target: TestContent.Identifier,
+            itemPosition: ListItemScrollPosition,
+            animated: Bool = false,
+            scrollInterruptionPolicy: AutoScrollAction.ScrollInterruptionPolicy = .performImmediately,
+            shouldPerform: @escaping (ListScrollPositionInfo) -> Bool = { _ in true },
+            didPerform: @escaping (ListScrollPositionInfo) -> Void = { _ in }
+        ) -> ListProperties {
+            ListProperties.default { list in
+                list.animatesChanges = animated
+                list.layout = .table { layout in
+                    layout.contentInsetAdjustmentBehavior = .never
+                }
+                list.sections = [
+                    Section("items") {
+                        for itemNumber in 1...100 {
+                            TestContent(content: "Item \(itemNumber)")
+                        }
+                    }
+                ]
+
+                list.autoScrollAction = .pin(
+                    .item(target),
+                    itemPosition: itemPosition,
+                    animated: animated,
+                    scrollInterruptionPolicy: scrollInterruptionPolicy,
+                    shouldPerform: shouldPerform,
+                    didPerform: didPerform
+                )
+            }
+        }
+
+        func makeInsertedAutoScrollContent(
+            insertedID: TestContent.Identifier,
+            itemPosition: ListItemScrollPosition,
+            didPerform: @escaping (ListScrollPositionInfo) -> Void
+        ) -> ListProperties {
+            ListProperties.default { list in
+                list.animatesChanges = false
+                list.layout = .table { layout in
+                    layout.contentInsetAdjustmentBehavior = .never
+                }
+                list.sections = [
+                    Section("items") {
+                        for itemNumber in 1...100 {
+                            TestContent(content: "Item \(itemNumber)")
+                        }
+                    }
+                ]
+
+                list.autoScrollAction = .scrollTo(
+                    .item(insertedID),
+                    onInsertOf: insertedID,
+                    itemPosition: itemPosition,
+                    animated: false,
+                    shouldPerform: { _ in true },
+                    didPerform: didPerform
+                )
+            }
+        }
+    }
+
+    func test_deferred_auto_scroll_action_with_vertical_content_offset_adjustment() throws {
+
+        try self.testcase("defers while dragging and runs when dragging ends") {
+            var didPerform: [ListScrollPositionInfo] = []
+            var capturedInfo: ListItemScrollPositionInfo?
+            var offsetAtAdjustment: CGFloat?
+
+            let vc = ViewController()
+            vc.listFramingBehavior = .exactly(CGSize(width: 400, height: 600))
+
+            try show(vc: vc) { vc in
+                vc.list.configure(with: makeAutoScrollContent())
+                waitFor { vc.list.updateQueue.isEmpty }
+
+                vc.list.delegate.scrollViewWillBeginDragging(vc.list.collectionView)
+                vc.list.configure(with: makeAutoScrollContent(
+                    contentOffsetAdjustment: { info in
+                        capturedInfo = info
+                        offsetAtAdjustment = vc.list.collectionView.contentOffset.y
+                        return 125.0
+                    },
+                    scrollInterruptionPolicy: .deferDuringUserScrolling,
+                    shouldPerform: { _ in true },
+                    didPerform: { didPerform.append($0) }
+                ))
+                waitFor { vc.list.updateQueue.isEmpty }
+
+                XCTAssertEqual(didPerform.count, 0)
+                XCTAssertEqual(vc.list.collectionView.contentOffset.y, 0.0, accuracy: 0.1)
+
+                vc.list.delegate.scrollViewDidEndDragging(vc.list.collectionView, willDecelerate: false)
+                waitFor { didPerform.count == 1 }
+
+                _ = try XCTUnwrap(capturedInfo)
+                XCTAssertEqual(
+                    vc.list.collectionView.contentOffset.y,
+                    try XCTUnwrap(offsetAtAdjustment) + 125.0,
+                    accuracy: 0.1
+                )
+            }
+        }
+
+        self.testcase("defers until deceleration ends") {
+            var didPerform: [ListScrollPositionInfo] = []
+
+            let vc = ViewController()
+            vc.listFramingBehavior = .exactly(CGSize(width: 400, height: 600))
+
+            show(vc: vc) { vc in
+                vc.list.configure(with: makeAutoScrollContent())
+                waitFor { vc.list.updateQueue.isEmpty }
+
+                vc.list.delegate.scrollViewWillBeginDragging(vc.list.collectionView)
+                vc.list.configure(with: makeAutoScrollContent(
+                    scrollInterruptionPolicy: .deferDuringUserScrolling,
+                    shouldPerform: { _ in true },
+                    didPerform: { didPerform.append($0) }
+                ))
+                waitFor { vc.list.updateQueue.isEmpty }
+
+                vc.list.delegate.scrollViewDidEndDragging(vc.list.collectionView, willDecelerate: true)
+                XCTAssertEqual(didPerform.count, 0)
+
+                vc.list.delegate.scrollViewDidEndDecelerating(vc.list.collectionView)
+                waitFor { didPerform.count == 1 }
+            }
+        }
+
+        self.testcase("re-evaluates shouldPerform when deferred scroll retries") {
+            var didPerform: [ListScrollPositionInfo] = []
+            var shouldPerform = false
+
+            let vc = ViewController()
+            vc.listFramingBehavior = .exactly(CGSize(width: 400, height: 600))
+
+            show(vc: vc) { vc in
+                vc.list.configure(with: makeAutoScrollContent())
+                waitFor { vc.list.updateQueue.isEmpty }
+
+                vc.list.delegate.scrollViewWillBeginDragging(vc.list.collectionView)
+                vc.list.configure(with: makeAutoScrollContent(
+                    scrollInterruptionPolicy: .deferDuringUserScrolling,
+                    shouldPerform: { _ in shouldPerform },
+                    didPerform: { didPerform.append($0) }
+                ))
+                waitFor { vc.list.updateQueue.isEmpty }
+
+                shouldPerform = true
+                vc.list.delegate.scrollViewDidEndDragging(vc.list.collectionView, willDecelerate: false)
+                waitFor { didPerform.count == 1 }
+            }
+        }
+
+        self.testcase("skips while dragging") {
+            var didPerform: [ListScrollPositionInfo] = []
+
+            let vc = ViewController()
+            vc.listFramingBehavior = .exactly(CGSize(width: 400, height: 600))
+
+            show(vc: vc) { vc in
+                vc.list.configure(with: makeAutoScrollContent())
+                waitFor { vc.list.updateQueue.isEmpty }
+
+                vc.list.delegate.scrollViewWillBeginDragging(vc.list.collectionView)
+                vc.list.configure(with: makeAutoScrollContent(
+                    scrollInterruptionPolicy: .skipDuringUserScrolling,
+                    shouldPerform: { _ in true },
+                    didPerform: { didPerform.append($0) }
+                ))
+                waitFor { vc.list.updateQueue.isEmpty }
+
+                XCTAssertEqual(didPerform.count, 0)
+
+                vc.list.delegate.scrollViewDidEndDragging(vc.list.collectionView, willDecelerate: false)
+                waitFor { vc.list.updateQueue.isEmpty }
+                XCTAssertEqual(didPerform.count, 0)
+            }
+        }
+
+        func makeAutoScrollContent(
+            contentOffsetAdjustment: @escaping ListItemScrollPositionAdjustment = { _ in 125.0 },
+            scrollInterruptionPolicy: AutoScrollAction.ScrollInterruptionPolicy = .performImmediately,
+            shouldPerform: @escaping (ListScrollPositionInfo) -> Bool = { _ in false },
+            didPerform: @escaping (ListScrollPositionInfo) -> Void = { _ in }
+        ) -> ListProperties {
+            ListProperties.default { list in
+                list.animatesChanges = false
+                list.layout = .table { layout in
+                    layout.contentInsetAdjustmentBehavior = .never
+                }
+                list.sections = [
+                    Section("items") {
+                        for itemNumber in 1...100 {
+                            TestContent(content: "Item \(itemNumber)")
+                        }
+                    }
+                ]
+
+                list.autoScrollAction = .pin(
+                    .item(TestContent.Identifier("Item 75")),
+                    itemPosition: .verticalContentOffsetAdjustment(contentOffsetAdjustment),
+                    animated: false,
+                    scrollInterruptionPolicy: scrollInterruptionPolicy,
+                    shouldPerform: shouldPerform,
+                    didPerform: didPerform
                 )
             }
         }
@@ -1053,12 +1401,14 @@ class ListViewTests: XCTestCase
 
         try testControllerCase("applies custom offset") { viewController in
             var capturedInfo: ListItemScrollPositionInfo?
+            var offsetAtAdjustment: CGFloat?
             let scrollExpectation = expectation(description: "Scroll completed")
 
             let didScroll = viewController.list.scrollTo(
                 item: TestContent.Identifier("Item 75"),
                 contentOffsetAdjustment: { info in
                     capturedInfo = info
+                    offsetAtAdjustment = viewController.list.collectionView.contentOffset.y
                     return 125.0
                 },
                 animated: false,
@@ -1069,23 +1419,28 @@ class ListViewTests: XCTestCase
 
             XCTAssertTrue(didScroll)
             wait(for: [scrollExpectation], timeout: 0.5)
-            XCTAssertEqual(viewController.list.collectionView.contentOffset.y, 125.0, accuracy: 0.1)
 
             let itemIndexPath = try XCTUnwrap(
                 viewController.list.storage.allContent.firstIndexPathForItem(with: TestContent.Identifier("Item 75"))
             )
-            XCTAssertEqual(capturedInfo?.itemFrame, viewController.list.collectionViewLayout.frameForItem(at: itemIndexPath))
-            XCTAssertEqual(capturedInfo?.visibleContentFrame.origin.y, 0.0, accuracy: 0.1)
-            XCTAssertEqual(capturedInfo?.positionInfo.isScrollInProgress, false)
+            let info = try XCTUnwrap(capturedInfo)
+            XCTAssertEqual(
+                viewController.list.collectionView.contentOffset.y,
+                try XCTUnwrap(offsetAtAdjustment) + 125.0,
+                accuracy: 0.1
+            )
+            XCTAssertEqual(info.itemFrame, viewController.list.collectionViewLayout.frameForItem(at: itemIndexPath))
+            XCTAssertEqual(info.visibleContentFrame.origin.y, 0.0, accuracy: 0.1)
+            XCTAssertEqual(info.positionInfo.isScrollInProgress, false)
         }
 
         try testControllerCase("clamps custom offset at bottom and top") { viewController in
-            let maxOffset = viewController.list.collectionViewLayout.collectionViewContentSize.height
-                - viewController.list.collectionView.visibleContentFrame.height
-                - viewController.list.collectionView.adjustedContentInset.top
-
             scrollWithAdjustment(100_000.0, item: TestContent.Identifier("Item 75"), using: viewController)
-            XCTAssertEqual(viewController.list.collectionView.contentOffset.y, maxOffset, accuracy: 0.1)
+            XCTAssertEqual(
+                viewController.list.collectionView.bounds.maxY,
+                viewController.list.collectionView.contentSize.height + viewController.list.collectionView.adjustedContentInset.bottom,
+                accuracy: 0.1
+            )
 
             scrollWithAdjustment(-100_000.0, item: TestContent.Identifier("Item 1"), using: viewController)
             XCTAssertEqual(

--- a/ListableUI/Tests/ListView/ListViewTests.swift
+++ b/ListableUI/Tests/ListView/ListViewTests.swift
@@ -1434,7 +1434,7 @@ class ListViewTests: XCTestCase
             XCTAssertEqual(info.positionInfo.isScrollInProgress, false)
         }
 
-        try testControllerCase("clamps custom offset at bottom and top") { viewController in
+        testControllerCase("clamps custom offset at bottom and top") { viewController in
             scrollWithAdjustment(100_000.0, item: TestContent.Identifier("Item 75"), using: viewController)
             XCTAssertEqual(
                 viewController.list.collectionView.bounds.maxY,
@@ -1450,7 +1450,7 @@ class ListViewTests: XCTestCase
             )
         }
 
-        try testControllerCase("runs completion for no-op custom offset") { viewController in
+        testControllerCase("runs completion for no-op custom offset") { viewController in
             let startingOffset = viewController.list.collectionView.contentOffset
             let scrollExpectation = expectation(description: "Scroll completed")
 
@@ -1468,7 +1468,7 @@ class ListViewTests: XCTestCase
             XCTAssertEqual(viewController.list.collectionView.contentOffset, startingOffset)
         }
 
-        try testControllerCase("runs completion for missing custom offset item") { viewController in
+        testControllerCase("runs completion for missing custom offset item") { viewController in
             let scrollExpectation = expectation(description: "Scroll completed")
 
             let didScroll = viewController.list.scrollTo(
@@ -1506,7 +1506,7 @@ class ListViewTests: XCTestCase
 
     func test_settled_scroll_callbacks_include_actions() throws {
 
-        try testControllerCase { viewController in
+        testControllerCase { viewController in
             var didEndDecelerationCanUseActions = false
             var didEndScrollingAnimationCanUseActions = false
 

--- a/ListableUI/Tests/ListView/ListViewTests.swift
+++ b/ListableUI/Tests/ListView/ListViewTests.swift
@@ -1535,6 +1535,52 @@ class ListViewTests: XCTestCase
             XCTAssertTrue(didEndScrollingAnimationCanUseActions)
         }
     }
+
+    func test_scroll_started_from_did_end_scrolling_animation_completes_on_next_scroll_end() {
+
+        testControllerCase { viewController in
+            var firstCompletionCount = 0
+            var secondCompletionCount = 0
+            var shouldStartSecondScroll = true
+
+            viewController.list.scrollCompletionHandlers.append { changes in
+                XCTAssertEqual(changes.positionInfo.bounds.size, CGSize(width: 400, height: 600))
+                firstCompletionCount += 1
+            }
+
+            viewController.list.stateObserver = ListStateObserver { observer in
+                observer.onDidEndScrollingAnimation { state in
+                    guard shouldStartSecondScroll else {
+                        return
+                    }
+
+                    shouldStartSecondScroll = false
+                    let didScroll = state.actions.scrolling.scrollTo(
+                        item: TestContent.Identifier("Item 50"),
+                        position: ScrollPosition(position: .top, ifAlreadyVisible: .scrollToPosition),
+                        animated: true,
+                        completion: { changes in
+                            XCTAssertEqual(changes.positionInfo.bounds.size, CGSize(width: 400, height: 600))
+                            secondCompletionCount += 1
+                        }
+                    )
+                    XCTAssertTrue(didScroll)
+                }
+            }
+
+            viewController.list.delegate.scrollViewDidEndScrollingAnimation(viewController.list.collectionView)
+
+            XCTAssertEqual(firstCompletionCount, 1)
+            XCTAssertEqual(secondCompletionCount, 0)
+            XCTAssertEqual(viewController.list.scrollCompletionHandlers.count, 1)
+
+            viewController.list.delegate.scrollViewDidEndScrollingAnimation(viewController.list.collectionView)
+
+            XCTAssertEqual(firstCompletionCount, 1)
+            XCTAssertEqual(secondCompletionCount, 1)
+            XCTAssertEqual(viewController.list.scrollCompletionHandlers.count, 0)
+        }
+    }
     
     func test_scroll_to_section_completion() throws {
         for animated in [true, false] {

--- a/ListableUI/Tests/ListView/ListViewTests.swift
+++ b/ListableUI/Tests/ListView/ListViewTests.swift
@@ -1113,6 +1113,27 @@ class ListViewTests: XCTestCase
             }
         }
 
+        self.testcase("defer policy performs immediately when not dragging") {
+            var didPerform: [ListScrollPositionInfo] = []
+
+            let vc = ViewController()
+            vc.listFramingBehavior = .exactly(CGSize(width: 400, height: 600))
+
+            show(vc: vc) { vc in
+                vc.list.configure(with: makeAutoScrollContent())
+                waitFor { vc.list.updateQueue.isEmpty }
+
+                vc.list.configure(with: makeAutoScrollContent(
+                    scrollInterruptionPolicy: .deferDuringUserScrolling,
+                    shouldPerform: { _ in true },
+                    didPerform: { didPerform.append($0) }
+                ))
+                waitFor { didPerform.count == 1 }
+
+                XCTAssertEqual(vc.list.collectionView.contentOffset.y, 125.0, accuracy: 0.1)
+            }
+        }
+
         self.testcase("re-evaluates shouldPerform when deferred scroll retries") {
             var didPerform: [ListScrollPositionInfo] = []
             var shouldPerform = false
@@ -1161,6 +1182,27 @@ class ListViewTests: XCTestCase
                 vc.list.delegate.scrollViewDidEndDragging(vc.list.collectionView, willDecelerate: false)
                 waitFor { vc.list.updateQueue.isEmpty }
                 XCTAssertEqual(didPerform.count, 0)
+            }
+        }
+
+        self.testcase("skip policy performs when not dragging") {
+            var didPerform: [ListScrollPositionInfo] = []
+
+            let vc = ViewController()
+            vc.listFramingBehavior = .exactly(CGSize(width: 400, height: 600))
+
+            show(vc: vc) { vc in
+                vc.list.configure(with: makeAutoScrollContent())
+                waitFor { vc.list.updateQueue.isEmpty }
+
+                vc.list.configure(with: makeAutoScrollContent(
+                    scrollInterruptionPolicy: .skipDuringUserScrolling,
+                    shouldPerform: { _ in true },
+                    didPerform: { didPerform.append($0) }
+                ))
+                waitFor { didPerform.count == 1 }
+
+                XCTAssertEqual(vc.list.collectionView.contentOffset.y, 125.0, accuracy: 0.1)
             }
         }
 

--- a/ListableUI/Tests/ListView/ListViewTests.swift
+++ b/ListableUI/Tests/ListView/ListViewTests.swift
@@ -1048,6 +1048,138 @@ class ListViewTests: XCTestCase
             }
         }
     }
+
+    func test_scroll_to_item_with_content_offset_adjustment() throws {
+
+        try testControllerCase("applies custom offset") { viewController in
+            var capturedInfo: ListItemScrollPositionInfo?
+            let scrollExpectation = expectation(description: "Scroll completed")
+
+            let didScroll = viewController.list.scrollTo(
+                item: TestContent.Identifier("Item 75"),
+                contentOffsetAdjustment: { info in
+                    capturedInfo = info
+                    return 125.0
+                },
+                animated: false,
+                completion: { _ in
+                    scrollExpectation.fulfill()
+                }
+            )
+
+            XCTAssertTrue(didScroll)
+            wait(for: [scrollExpectation], timeout: 0.5)
+            XCTAssertEqual(viewController.list.collectionView.contentOffset.y, 125.0, accuracy: 0.1)
+
+            let itemIndexPath = try XCTUnwrap(
+                viewController.list.storage.allContent.firstIndexPathForItem(with: TestContent.Identifier("Item 75"))
+            )
+            XCTAssertEqual(capturedInfo?.itemFrame, viewController.list.collectionViewLayout.frameForItem(at: itemIndexPath))
+            XCTAssertEqual(capturedInfo?.visibleContentFrame.origin.y, 0.0, accuracy: 0.1)
+            XCTAssertEqual(capturedInfo?.positionInfo.isScrollInProgress, false)
+        }
+
+        try testControllerCase("clamps custom offset at bottom and top") { viewController in
+            let maxOffset = viewController.list.collectionViewLayout.collectionViewContentSize.height
+                - viewController.list.collectionView.visibleContentFrame.height
+                - viewController.list.collectionView.adjustedContentInset.top
+
+            scrollWithAdjustment(100_000.0, item: TestContent.Identifier("Item 75"), using: viewController)
+            XCTAssertEqual(viewController.list.collectionView.contentOffset.y, maxOffset, accuracy: 0.1)
+
+            scrollWithAdjustment(-100_000.0, item: TestContent.Identifier("Item 1"), using: viewController)
+            XCTAssertEqual(
+                viewController.list.collectionView.contentOffset.y,
+                -viewController.list.collectionView.adjustedContentInset.top,
+                accuracy: 0.1
+            )
+        }
+
+        try testControllerCase("runs completion for no-op custom offset") { viewController in
+            let startingOffset = viewController.list.collectionView.contentOffset
+            let scrollExpectation = expectation(description: "Scroll completed")
+
+            let didScroll = viewController.list.scrollTo(
+                item: TestContent.Identifier("Item 1"),
+                contentOffsetAdjustment: { _ in 0.0 },
+                animated: true,
+                completion: { _ in
+                    scrollExpectation.fulfill()
+                }
+            )
+
+            XCTAssertTrue(didScroll)
+            wait(for: [scrollExpectation], timeout: 0.5)
+            XCTAssertEqual(viewController.list.collectionView.contentOffset, startingOffset)
+        }
+
+        try testControllerCase("runs completion for missing custom offset item") { viewController in
+            let scrollExpectation = expectation(description: "Scroll completed")
+
+            let didScroll = viewController.list.scrollTo(
+                item: TestContent.Identifier("Missing"),
+                contentOffsetAdjustment: { _ in
+                    XCTFail("Unexpected adjustment request")
+                    return 0.0
+                },
+                animated: true,
+                completion: { _ in
+                    scrollExpectation.fulfill()
+                }
+            )
+
+            XCTAssertFalse(didScroll)
+            wait(for: [scrollExpectation], timeout: 0.5)
+            XCTAssertEqual(viewController.list.collectionView.contentOffset.y, 0.0, accuracy: 0.1)
+        }
+
+        func scrollWithAdjustment(_ adjustment: CGFloat, item: TestContent.Identifier, using viewController: ViewController) {
+            let scrollExpectation = expectation(description: "Scroll completed")
+            let didScroll = viewController.list.scrollTo(
+                item: item,
+                contentOffsetAdjustment: { _ in adjustment },
+                animated: false,
+                completion: { _ in
+                    scrollExpectation.fulfill()
+                }
+            )
+
+            XCTAssertTrue(didScroll)
+            wait(for: [scrollExpectation], timeout: 0.5)
+        }
+    }
+
+    func test_settled_scroll_callbacks_include_actions() throws {
+
+        try testControllerCase { viewController in
+            var didEndDecelerationCanUseActions = false
+            var didEndScrollingAnimationCanUseActions = false
+
+            viewController.list.stateObserver = ListStateObserver { observer in
+                observer.onDidEndDeceleration { state in
+                    didEndDecelerationCanUseActions = state.actions.scrolling.scrollTo(
+                        item: TestContent.Identifier("Item 20"),
+                        position: ScrollPosition(position: .top),
+                        animated: false
+                    )
+                }
+
+                observer.onDidEndScrollingAnimation { state in
+                    didEndScrollingAnimationCanUseActions = state.actions.scrolling.scrollTo(
+                        item: TestContent.Identifier("Item 21"),
+                        position: ScrollPosition(position: .top),
+                        animated: false
+                    )
+                }
+            }
+
+            viewController.list.delegate.scrollViewDidEndDecelerating(viewController.list.collectionView)
+            viewController.list.delegate.scrollViewDidEndScrollingAnimation(viewController.list.collectionView)
+
+            XCTAssertTrue(didEndDecelerationCanUseActions)
+            XCTAssertTrue(didEndScrollingAnimationCanUseActions)
+        }
+    }
     
     func test_scroll_to_section_completion() throws {
         for animated in [true, false] {


### PR DESCRIPTION
Adds a Listable-owned API for custom vertical item positioning from both imperative `ListActions` and declarative `AutoScrollAction`.

### What's changed

- Adds `ListItemScrollPosition.standard(_:)` and `.verticalContentOffsetAdjustment(_:)`.
- Adds `AutoScrollAction.scrollTo(... itemPosition:)` and `pin(... itemPosition:)`, with existing `position:` overloads preserved.
- Adds `AutoScrollAction.ScrollInterruptionPolicy`:
  - `.performImmediately`
  - `.deferDuringUserScrolling`
  - `.skipDuringUserScrolling`
- Keeps custom adjustments vertical-only; no horizontal offset API is added.
- Adds a generic demo: `Custom Auto Scrolling (Footer-Aware Pin)`.
- Adds tests for custom declarative auto-scroll, callback behavior, deferral, and skip policy.

### Example

```swift
list.autoScrollAction = .pin(
    .item(targetIdentifier),
    itemPosition: .verticalContentOffsetAdjustment { info in
        max(0.0, info.itemFrame.maxY - info.visibleContentFrame.maxY)
    },
    scrollInterruptionPolicy: .deferDuringUserScrolling
)
```

Use `.skipDuringUserScrolling` when an auto-scroll request should be dropped instead of retried after user scrolling ends.

### Visuals

https://github.com/user-attachments/assets/177a8ffb-ae96-4860-938a-af93d5655a75


### Test Plan

- [x] `mise exec -- xcodebuild test -workspace Development/ListableDevelopment.xcworkspace -scheme ListableDevelopment-Workspace -destination 'id=52DC49DC-0376-4B43-99BE-BC7A016A51B3' -derivedDataPath /tmp/listable-dd-development-tests -only-testing:ListableTests`
- [x] `git diff --check`
- [x] Built and launched `Custom Auto Scrolling (Footer-Aware Pin)` demo on iOS Simulator

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.