### PR TITLE
Hide SwipeActionsView from the accessibility tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- Hid `SwipeActionsView` from the accessibility tree so VoiceOver no longer surfaces invisible, off-screen swipe action buttons. Swipe actions remain available via `accessibilityCustomActions` on the list item.
+- Hid swipe action buttons from VoiceOver while the swipe is closed. The buttons become accessibility elements again once the swipe is open, so the row's `accessibilityCustomActions` no longer competes with invisible, off-screen buttons.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Hid `SwipeActionsView` from the accessibility tree so VoiceOver no longer surfaces invisible, off-screen swipe action buttons. Swipe actions remain available via `accessibilityCustomActions` on the list item.
+
 ### Added
 
 ### Removed

--- a/ListableUI/Sources/Internal/SwipeActionsView.swift
+++ b/ListableUI/Sources/Internal/SwipeActionsView.swift
@@ -68,6 +68,12 @@ final class SwipeActionsView: UIView {
         super.init(frame: .zero)
         clipsToBounds = true
 
+        // The swipe action buttons are an implementation detail of the swipe gesture's
+        // visual. VoiceOver interacts with swipe actions via `accessibilityCustomActions`
+        // on the enclosing `ContentViewContainer`; exposing the buttons here as well
+        // surfaces invisible, unactivatable elements when the swipe is closed.
+        accessibilityElementsHidden = true
+
         addSubview(container)
     }
 

--- a/ListableUI/Sources/Internal/SwipeActionsView.swift
+++ b/ListableUI/Sources/Internal/SwipeActionsView.swift
@@ -68,10 +68,10 @@ final class SwipeActionsView: UIView {
         super.init(frame: .zero)
         clipsToBounds = true
 
-        // The swipe action buttons are an implementation detail of the swipe gesture's
-        // visual. VoiceOver interacts with swipe actions via `accessibilityCustomActions`
-        // on the enclosing `ContentViewContainer`; exposing the buttons here as well
-        // surfaces invisible, unactivatable elements when the swipe is closed.
+        // The swipe action buttons live off-screen with zero width when the swipe is
+        // closed, so they must be hidden from VoiceOver in that state — otherwise users
+        // land on invisible, unactivatable elements between rows. `apply(state:)` toggles
+        // this back on whenever the actions are actually visible.
         accessibilityElementsHidden = true
 
         addSubview(container)
@@ -232,7 +232,9 @@ final class SwipeActionsView: UIView {
     func apply(state newState: SwipeActionState) {
         let priorState = state
         state = newState
-        
+
+        accessibilityElementsHidden = (newState == .closed)
+
         guard newState.isRelevantFor(side: side) else {
             return
         }

--- a/ListableUI/Sources/Internal/SwipeActionsView.swift
+++ b/ListableUI/Sources/Internal/SwipeActionsView.swift
@@ -67,11 +67,6 @@ final class SwipeActionsView: UIView {
         self.didPerformAction = didPerformAction
         super.init(frame: .zero)
         clipsToBounds = true
-
-        // The swipe action buttons live off-screen with zero width when the swipe is
-        // closed, so they must be hidden from VoiceOver in that state — otherwise users
-        // land on invisible, unactivatable elements between rows. `apply(state:)` toggles
-        // this back on whenever the actions are actually visible.
         accessibilityElementsHidden = true
 
         addSubview(container)


### PR DESCRIPTION
When a list item has swipe actions, the `DefaultSwipeActionButton` instances stayed in the accessibility tree even while the swipe was closed — the buttons were positioned off-screen, so VoiceOver ignores them under standard conditions but animations like rotation could still expose them momentarily allowing selection of "Void"/"Repeat"/"Delete" elements.

`SwipeActionsView` now starts with `accessibilityElementsHidden = true` (matching its initial `.closed` state) and toggles in `apply(state:)`: hidden while `.closed`, exposed once the actions are open/swiping. The row's `accessibilityCustomActions` is unaffected, so VoiceOver can still trigger swipe actions via the Actions rotor without opening the swipe; once opened, the visible buttons are also reachable directly.

### Checklist

Please do the following before merging:

- [ ] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.