### PR TITLE
ci: bump jdx/mise-action from v2 to v3

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v3
 
       - name: Read env
         run: cat .github/workflows/env.properties >> $GITHUB_ENV

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
 
       - name: Read env
         run: cat .github/workflows/env.properties >> $GITHUB_ENV

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Mise
-        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
 
       - name: Read env
         run: cat .github/workflows/env.properties >> $GITHUB_ENV


### PR DESCRIPTION
The `jdx/mise-action@v2` tag was resolving to a commit that intermittently failed to download from `codeload.github.com`, blocking every CI job at the "Set up job" step (e.g. #616). Bumping to `@v3` points the workflow at a different commit that downloads reliably.

The action is used with zero inputs (`.github/workflows/run_tests.yml:41`), so the major-version bump is a drop-in replacement for our usage.

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.