### PR TITLE
Plumb isSelectable into ApplyItemContentInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added `isSelectable` to `ApplyItemContentInfo`, reflecting whether the item's `selectionStyle` is interactive (`.tappable`, `.selectable`, or `.toggles`). `ItemContent` implementations can read this to represent themselves as interactive, for example by applying the `.button` accessibility trait so VoiceOver users know the item responds to taps.
+
 ### Removed
 
 ### Changed

--- a/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
+++ b/ListableUI/Sources/Internal/PresentationState/PresentationState.ItemState.swift
@@ -312,6 +312,7 @@ extension PresentationState
                     cell.openTrailingSwipeActions()
                 },
                 isReorderable: self.model.reordering != nil,
+                isSelectable: self.model.selectionStyle.isSelectable,
                 environment: environment
             )
             

--- a/ListableUI/Sources/Item/ItemContent.swift
+++ b/ListableUI/Sources/Item/ItemContent.swift
@@ -565,7 +565,12 @@ public struct ApplyItemContentInfo
     /// If the item can be reordered.
     /// Use this property to determine if your `ItemContent` should display a reorder control.
     public var isReorderable : Bool
-    
+
+    /// If the item is selectable; that is, if its `selectionStyle` is `.tappable`, `.selectable`, or `.toggles`.
+    /// Use this property to determine if your `ItemContent` should represent itself as interactive, for example
+    /// by applying the `.button` accessibility trait so VoiceOver users know the item responds to taps.
+    public var isSelectable : Bool = false
+
     /// The environment of the containing list.
     /// See `ListEnvironment` for usage information.
     public var environment : ListEnvironment

--- a/ListableUI/Sources/Item/ItemContent.swift
+++ b/ListableUI/Sources/Item/ItemContent.swift
@@ -569,7 +569,7 @@ public struct ApplyItemContentInfo
     /// If the item is selectable; that is, if its `selectionStyle` is `.tappable`, `.selectable`, or `.toggles`.
     /// Use this property to determine if your `ItemContent` should represent itself as interactive, for example
     /// by applying the `.button` accessibility trait so VoiceOver users know the item responds to taps.
-    public var isSelectable : Bool = false
+    public var isSelectable : Bool
 
     /// The environment of the containing list.
     /// See `ListEnvironment` for usage information.

--- a/ListableUI/Tests/Internal/Presentation State/PresentationState.ItemStateTests.swift
+++ b/ListableUI/Tests/Internal/Presentation State/PresentationState.ItemStateTests.swift
@@ -318,6 +318,58 @@ class PresentationState_ItemStateTests : XCTestCase
         XCTAssertEqual(state.coordination.coordinator?.willDisplay_calls.count, 1)
         XCTAssertEqual(state.coordination.coordinator?.didEndDisplay_calls.count, 1)
     }
+
+    func test_applyTo_isSelectable()
+    {
+        XCTAssertEqual(appliedInfo(for: .tappable).isSelectable, true)
+        XCTAssertEqual(appliedInfo(for: .notSelectable).isSelectable, false)
+    }
+
+    /// Builds an `ItemState` for the given `selectionStyle`, applies it to a cell, and returns the `ApplyItemContentInfo` passed to the content.
+    private func appliedInfo(for selectionStyle : ItemSelectionStyle) -> ApplyItemContentInfo
+    {
+        var applied : ApplyItemContentInfo?
+
+        let item = Item(CapturingContent { applied = $0 }, selectionStyle: selectionStyle)
+
+        let state = PresentationState.ItemState(
+            with: item,
+            dependencies: ItemStateDependencies(
+                reorderingDelegate: ReorderingActionsDelegateMock(),
+                coordinatorDelegate: ItemContentCoordinatorDelegateMock(),
+                environmentProvider: { .empty }
+            ),
+            updateCallbacks: UpdateCallbacks(.immediate, wantsAnimations: false),
+            performsContentCallbacks: true
+        )
+
+        state.applyTo(
+            cell: ItemCell<CapturingContent>(frame: .zero),
+            itemState: .init(isSelected: false, isHighlighted: false, isReordering: false),
+            reason: .willDisplay,
+            environment: .empty
+        )
+
+        return applied!
+    }
+}
+
+
+fileprivate struct CapturingContent : ItemContent
+{
+    typealias ContentView = UIView
+
+    let onApply : (ApplyItemContentInfo) -> ()
+
+    var identifierValue : String { "" }
+
+    func isEquivalent(to other : CapturingContent) -> Bool { false }
+
+    func apply(to views : ItemContentViews<CapturingContent>, for reason : ApplyReason, with info : ApplyItemContentInfo) {
+        onApply(info)
+    }
+
+    static func createReusableContentView(frame : CGRect) -> UIView { UIView(frame: frame) }
 }
 
 


### PR DESCRIPTION
## Why

A `ListableUI` item's selection behavior lives in its wrapper — `Item.selectionStyle` drives the tap handling, highlight, and selection state at the list level. The contained `ItemContent` view that actually renders on screen has no way to know that its surrounding cell is interactive.

That's a problem for accessibility: when a row is tappable, the content view often needs to represent that itself (for example by applying the `.button` accessibility trait so VoiceOver announces the row as actionable). Without this signal, the content view is blind to the interaction happening in its wrapper and can't reflect it.

## What

Adds an `isSelectable` flag to `ApplyItemContentInfo`, so a content view is told — at `apply(to:for:with:)` time — whether the item it lives in is interactive.

It's populated in `PresentationState.ItemState.applyTo` from `selectionStyle.isSelectable`:

- `true` for `.tappable`, `.selectable`, and `.toggles`
- `false` for `.notSelectable`

Live selection/highlight state is already available via `info.state`; this fills the remaining gap of "is this row interactive at all." No trait is forced at the ListableUI/Blueprint level — what to do with the signal stays each content view's call.

TBHFUZZ-165

### Checklist

Please do the following before merging:

- [x] Ensure any public-facing changes are reflected in the [changelog](https://github.com/square/Listable/blob/main/CHANGELOG.md). Include them in the `Main` section.

---

_This issue was discovered via agentic fuzz testing using [The Button Heist](https://github.com/RoyalPineapple/TheButtonHeist)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
